### PR TITLE
We don not mount devtmpfs anymore in container

### DIFF
--- a/base/pm/process/containerprocess.go
+++ b/base/pm/process/containerprocess.go
@@ -3,9 +3,9 @@ package process
 import (
 	"encoding/json"
 	"fmt"
+	psutils "github.com/shirou/gopsutil/process"
 	"github.com/zero-os/0-core/base/pm/core"
 	"github.com/zero-os/0-core/base/pm/stream"
-	psutils "github.com/shirou/gopsutil/process"
 	"io"
 	"os"
 	"os/exec"

--- a/core0/subsys/containers/network.go
+++ b/core0/subsys/containers/network.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pborman/uuid"
+	"github.com/vishvananda/netlink"
 	"github.com/zero-os/0-core/base/pm"
 	"github.com/zero-os/0-core/base/pm/core"
 	"github.com/zero-os/0-core/base/pm/process"
-	"github.com/pborman/uuid"
-	"github.com/vishvananda/netlink"
 	"io/ioutil"
 	"net"
 	"os"
@@ -123,10 +123,6 @@ func (c *container) postBridge(dev string, index int, n *Nic) error {
 		return fmt.Errorf("get peer: %s", err)
 	}
 
-	if err := netlink.LinkSetUp(peer); err != nil {
-		return fmt.Errorf("set peer up: %s", err)
-	}
-
 	if err := netlink.LinkSetNsPid(peer, c.PID); err != nil {
 		return fmt.Errorf("set ns pid: %s", err)
 	}
@@ -176,7 +172,7 @@ func (c *container) postBridge(dev string, index int, n *Nic) error {
 			"ip", "link", "set", "dev", dev, "up")
 
 		if err != nil {
-			return fmt.Errorf("error brinding interface up: %v", err)
+			return fmt.Errorf("error bringing interface up: %v", err)
 		}
 
 		//setting the ip address

--- a/coreX/main.go
+++ b/coreX/main.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/op/go-logging"
 	"github.com/zero-os/0-core/base"
 	"github.com/zero-os/0-core/base/pm"
 	pmcore "github.com/zero-os/0-core/base/pm/core"
 	"github.com/zero-os/0-core/coreX/bootstrap"
 	"github.com/zero-os/0-core/coreX/options"
-	"github.com/op/go-logging"
 
 	"os/signal"
 	"syscall"
@@ -26,7 +26,7 @@ var (
 func init() {
 	formatter := logging.MustStringFormatter("%{color}%{module} %{level:.1s} > %{message} %{color:reset}")
 	logging.SetFormatter(formatter)
-	logging.SetLevel(logging.DEBUG, "")
+	logging.SetLevel(logging.INFO, "")
 }
 
 func handleSignal(bs *bootstrap.Bootstrap) {


### PR DESCRIPTION
Instead we use a normal tmpfs and then create the minimum
needed devices before we lower the capabilities

Fixes #228