### PR TITLE
Change memory Unit in MiB instead of MB

### DIFF
--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -591,7 +591,7 @@ func (m *kvmManager) mkDomain(seq uint16, params *CreateParams) (*Domain, error)
 		UUID: uuid.New(),
 		Memory: Memory{
 			Capacity: params.Memory,
-			Unit:     "MB",
+			Unit:     "MiB",
 		},
 		VCPU: params.CPU,
 		OS: OS{


### PR DESCRIPTION
This makes units passed from the client follow standards better

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>