### PR TITLE
Use Exception instead of BaseException

### DIFF
--- a/client/py-client/zeroos/core0/client/typchk.py
+++ b/client/py-client/zeroos/core0/client/typchk.py
@@ -6,11 +6,11 @@ def primitive(typ):
     return typ in [str, int, float, bool]
 
 
-class CheckerException(BaseException):
+class CheckerException(Exception):
     pass
 
 
-class Tracker(BaseException):
+class Tracker(Exception):
     def __init__(self, base):
         self._base = base
         self._reason = None


### PR DESCRIPTION
Most python code does try except Exception
Which causes certain deaemon to crash as they dont except BaseException

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>