### PR TITLE
Stream Subscribers, and job tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Build Status](https://api.travis-ci.org/zero-os/0-core.svg?branch=master)](https://travis-ci.org/zero-os/0-core/)
 [![codecov](https://codecov.io/gh/g8os/core0/branch/master/graph/badge.svg)](https://codecov.io/gh/g8os/core0)
 
-# Core0
+# 0-core
 
-Core0 is a `systemd` replacement for G8OS.
+The core of Zero-OS is 0-core, which is the Zero-OS replacement for systemd.
 
 ## Branches
 
@@ -20,9 +20,9 @@ See the release schedule in the [Zero-OS home repository](https://github.com/zer
 
 ## Development setup
 
-To run Core0 in a container, just run the following command, which will pull the needed image as well:
+To run Zero-OS in a Docker container, just run the following command, which will pull the needed image as well:
 
-```
+```bash
 docker run --privileged -d --name core -p 6379:6379 g8os/g8os-dev:1.0
 ```
 
@@ -38,7 +38,7 @@ Before using the client make sure the `./pyclient` is in your `PYTHONPATH`.
 ```python
 import client
 
-cl = client.Client(host='ip of docker container running core0')
+cl = client.Client(host='<IP address of Docker container running Zero-OS>')
 
 #validate that core0 is reachable
 print(cl.ping())
@@ -61,7 +61,7 @@ print(
 ## Features
 
 ### v0.9
-- Boot the core0 as init process
+- Boot the 0-core as init process
 - Manage disks
 - Create containers
   - Full Namespace isolation
@@ -77,13 +77,13 @@ print(
 - change datastore for fuse filesystem from ipfs to [Zero-OS Store](https://github.com/g8os/stor).
 
 ### v0.11
-- include of the monitoring of all processes running on the g8os.
+- include of the monitoring of all processes running on the Zero-OS.
   It produces aggregated statistics on the processes that can be dump into a time series database and displayed used something like Grafana.
 
 ### v1.0.0
-- New Flist format, the Flist used in the 0-FS is now a distributed as a RocksDB database.
+- New Flist format, the flist used in the 0-fs is now a distributed as a RocksDB database.
 - Creation of the [0-Hub](https://github.com/zero-os/core0/tree/1.0.0), see https://github.com/zero-os/0-hub
-- Improvement of the builtin commands of core0 and coreX
+- Improvement of the builtin commands of 0-core and coreX
 
 ### v1.1.0-alpha2
 - Lots and lots of bug fixes
@@ -92,8 +92,8 @@ print(
 - Libvirt bindings
 - Processes API
 - Support multiple ZeroTier in container networking
-- Support OpenVSwitch networking for both containers and KVM domains
-- `corectl` command line tool to manage core0 from within the node
+- Support Open vSwitch networking for both containers and KVM domains
+- `corectl` command line tool to manage Zero-OS from within the node
 
 ### Next
 

--- a/base/pm/core/command.go
+++ b/base/pm/core/command.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Route string
+type Tags []string
 
 //Cmd is an executable command
 type Command struct {
@@ -16,10 +17,11 @@ type Command struct {
 	StatsInterval   int              `json:"stats_interval,omitempty"`
 	MaxTime         int              `json:"max_time,omitempty"`
 	MaxRestart      int              `json:"max_restart,omitempty"`
+	Name            string           `json:"name"`
 	RecurringPeriod int              `json:"recurring_period,omitempty"`
 	Stream          bool             `json:"stream"`
 	LogLevels       []int            `json:"log_levels,omitempty"`
-	Tags            string           `json:"tags"`
+	Tags            Tags           `json:"tags"`
 
 	Route     Route `json:"-"`
 	Protected bool  `json:"-"`

--- a/base/pm/core/command.go
+++ b/base/pm/core/command.go
@@ -17,7 +17,6 @@ type Command struct {
 	StatsInterval   int              `json:"stats_interval,omitempty"`
 	MaxTime         int              `json:"max_time,omitempty"`
 	MaxRestart      int              `json:"max_restart,omitempty"`
-	Name            string           `json:"name"`
 	RecurringPeriod int              `json:"recurring_period,omitempty"`
 	Stream          bool             `json:"stream"`
 	LogLevels       []int            `json:"log_levels,omitempty"`

--- a/base/pm/core/result.go
+++ b/base/pm/core/result.go
@@ -42,7 +42,7 @@ type JobResult struct {
 	State     string  `json:"state"`
 	StartTime int64   `json:"starttime"`
 	Time      int64   `json:"time"`
-	Tags      string  `json:"tags"`
+	Tags      Tags    `json:"tags"`
 	Container uint64  `json:"container"`
 }
 

--- a/client/go-client/core.go
+++ b/client/go-client/core.go
@@ -7,6 +7,10 @@ import (
 	"github.com/google/shlex"
 )
 
+var (
+	NotFound = fmt.Errorf("not found")
+)
+
 type Job struct {
 	Command   Command `json:"cmd"`
 	CPU       float64 `json:"cpu"`
@@ -139,7 +143,7 @@ func (s *coreMgr) Job(job JobId) (*Job, error) {
 	}
 
 	if len(jobs) == 0 {
-		return nil, fmt.Errorf("not found")
+		return nil, NotFound
 	}
 
 	return &jobs[0], err
@@ -177,7 +181,7 @@ func (s *coreMgr) Process(pid ProcessId) (*Process, error) {
 	}
 
 	if len(processes) == 0 {
-		return nil, fmt.Errorf("not found")
+		return nil, NotFound
 	}
 
 	return &processes[0], err

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -1826,7 +1826,6 @@ class KvmManager:
             typchk.Map(int, int),
             typchk.IsNone()
         ),
-        'tags': typchk.Or([str], typchk.IsNone()),
     })
 
     _domain_action_chk = typchk.Checker({

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -956,7 +956,7 @@ class ContainerManager:
     def __init__(self, client):
         self._client = client
 
-    def create(self, root_url, mount=None, host_network=False, nics=DefaultNetworking, port=None, hostname=None, privileged=True, storage=None, name=None, tags=None):
+    def create(self, root_url, mount=None, host_network=False, nics=DefaultNetworking, port=None, hostname=None, privileged=False, storage=None, name=None, tags=None):
         """
         Creater a new container with the given root flist, mount points and
         zerotier id, and connected to the given bridges

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -782,6 +782,8 @@ class ContainerClient(BaseClient):
             'max_time': typchk.Or(int, typchk.IsNone()),
             'stream': bool,
             'tags': typchk.Or([str], typchk.IsNone()),
+            'id': typchk.Or(str, typchk.IsNone()),
+
         }
     })
 

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -687,6 +687,8 @@ class BaseClient:
         :param max_time: kill job server side if it exceeded this amount of seconds
         :param stream: If True, process stdout and stderr are pushed to a special queue (stream:<id>) so
             client can stream output
+        :param tags: job tags
+        :param id: job id. Generated if not supplied
         :return: Response object
         """
         raise NotImplemented()
@@ -694,7 +696,11 @@ class BaseClient:
     def sync(self, command, arguments, tags=None, id=None):
         """
         Same as self.raw except it do a response.get() waiting for the command execution to finish and reads the result
-
+        :param command: Command name to execute supported by the node (ex: core.system, info.cpu, etc...)
+                        check documentation for list of built in commands
+        :param arguments: A dict of required command arguments depends on the command name.
+        :param tags: job tags
+        :param id: job id. Generated if not supplied
         :return: Result object
         """
         response = self.raw(command, arguments, tags=tags, id=id)
@@ -739,6 +745,7 @@ class BaseClient:
         :param dir: CWD of command
         :param stdin: Stdin data to feed to the command stdin
         :param env: dict with ENV variables that will be exported to the command
+        :param id: job id. Auto generated if not defined.
         :return:
         """
         parts = shlex.split(command)
@@ -765,6 +772,7 @@ class BaseClient:
 
         :param script: Script to execute (can be multiline script)
         :param stdin: Stdin data to feed to the script
+        :param id: job id. Auto generated if not defined.
         :return:
         """
         args = {
@@ -860,6 +868,8 @@ class ContainerClient(BaseClient):
         :param max_time: kill job server side if it exceeded this amount of seconds
         :param stream: If True, process stdout and stderr are pushed to a special queue (stream:<id>) so
             client can stream output
+        :param tags: job tags
+        :param id: job id. Generated if not supplied
         :return: Response object
         """
         args = {
@@ -2476,6 +2486,8 @@ class Client(BaseClient):
         :param max_time: kill job server side if it exceeded this amount of seconds
         :param stream: If True, process stdout and stderr are pushed to a special queue (stream:<id>) so
             client can stream output
+        :param tags: job tags
+        :param id: job id. Generated if not supplied
         :return: Response object
         """
         if not id:

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -32,49 +32,76 @@ class Return:
 
     @property
     def payload(self):
+        """
+        Raw return object data  
+        :return: dict
+        """
         return self._payload
 
     @property
     def id(self):
+        """
+        Job ID
+        :return: string 
+        """
         return self._payload['id']
 
     @property
     def data(self):
         """
-        data returned by the process. Only available if process
+        Data returned by the process. Only available if process
         output data with the correct core level
+        
+        For example, if a job returns a json object the self.level will be 20 and the data will contain the serialized
+        json object, other levels exists for yaml, toml, etc... it really depends on the running job
+        return: python primitive (str, number, dict or array)
         """
         return self._payload['data']
 
     @property
     def level(self):
-        """data message level (if any)"""
+        """
+        Data message level (if any)
+        """
         return self._payload['level']
 
     @property
     def starttime(self):
-        """timestamp"""
+        """
+        Starttime as a timestamp
+        """
         return self._payload['starttime'] / 1000
 
     @property
     def time(self):
-        """execution time in millisecond"""
+        """
+        Execution time in millisecond
+        """
         return self._payload['time']
 
     @property
     def state(self):
         """
-        exit state
+        Exit state
+        :return: str one of [SUCCESS, ERROR, KILLED, TIMEOUT, UNKNOWN_CMD, DUPLICATE_ID]
         """
         return self._payload['state']
 
     @property
     def stdout(self):
+        """
+        The job stdout
+        :return: string or None
+        """
         streams = self._payload.get('streams', None)
         return streams[0] if streams is not None and len(streams) >= 1 else ''
 
     @property
     def stderr(self):
+        """
+        The job stderr
+        :return: string or None
+        """
         streams = self._payload.get('streams', None)
         return streams[1] if streams is not None and len(streams) >= 2 else ''
 
@@ -104,16 +131,31 @@ class Response:
 
     @property
     def id(self):
+        """
+        Job ID
+        :return: string 
+        """
         return self._id
 
     @property
     def exists(self):
+        """
+        Returns true if the job is still running or zero-os still knows about this job ID
+        
+        After a job is finished, a job remains on zero-os for max of 5min where you still can read the job result
+        after the 5 min is gone, the job result is no more fetchable
+        :return: bool
+        """
         r = self._client._redis
         flag = '{}:flag'.format(self._queue)
         return bool(r.execute_command('LKEYEXISTS', flag))
 
     @property
     def running(self):
+        """
+        Returns true if job still in running state
+        :return: 
+        """
         r = self._client._redis
         flag = '{}:flag'.format(self._queue)
         if bool(r.execute_command('LKEYEXISTS', flag)):
@@ -162,6 +204,16 @@ class Response:
                 w.write('\n')
 
     def get(self, timeout=None):
+        """
+        Waits for a job to finish (max of given timeout seconds) and return job results. When a job exits get() will
+        keep returning the same result until zero-os doesn't remember the job anymore (self.exists == False)
+        
+        :notes: the timeout here is a client side timeout, it's different than the timeout given to the job on start
+        (like in system method) witch will cause the job to be killed if it exceeded this timeout.
+        
+        :param timeout: max time to wait for the job to finish in seconds
+        :return: Return object
+        """
         if timeout is None:
             timeout = self._client.timeout
         r = self._client._redis
@@ -188,24 +240,52 @@ class InfoManager:
         self._client = client
 
     def cpu(self):
+        """
+        CPU information
+        :return: 
+        """
         return self._client.json('info.cpu', {})
 
     def nic(self):
+        """
+        Return (physical) network devices information including IPs
+        :return: 
+        """
         return self._client.json('info.nic', {})
 
     def mem(self):
+        """
+        Memory information
+        :return: 
+        """
         return self._client.json('info.mem', {})
 
     def disk(self):
+        """
+        Disk information
+        :return: 
+        """
         return self._client.json('info.disk', {})
 
     def os(self):
+        """
+        Operating system info
+        :return: 
+        """
         return self._client.json('info.os', {})
 
     def port(self):
+        """
+        Return information about open ports on the system (similar to netstat)
+        :return: 
+        """
         return self._client.json('info.port', {})
 
     def version(self):
+        """
+        Return OS version
+        :return: 
+        """
         return self._client.json('info.version', {})
 
 
@@ -540,22 +620,42 @@ class BaseClient:
 
     @property
     def info(self):
+        """
+        info manager
+        :return: 
+        """
         return self._info
 
     @property
     def job(self):
+        """
+        job manager
+        :return: 
+        """
         return self._job
 
     @property
     def process(self):
+        """
+        process manager
+        :return: 
+        """
         return self._process
 
     @property
     def filesystem(self):
+        """
+        filesystem manager
+        :return: 
+        """
         return self._filesystem
 
     @property
     def ip(self):
+        """
+        ip manager
+        :return: 
+        """
         return self._ip
 
     def raw(self, command, arguments, queue=None, max_time=None, stream=False):
@@ -591,7 +691,7 @@ class BaseClient:
     def json(self, command, arguments):
         """
         Same as self.sync except it assumes the returned result is json, and loads the payload of the return object
-
+        if the returned (data) is not of level (20) an error is raised.
         :Return: Data
         """
         result = self.sync(command, arguments)
@@ -693,10 +793,17 @@ class ContainerClient(BaseClient):
 
     @property
     def container(self):
+        """
+        :return: container id 
+        """
         return self._container
 
     @property
     def zerotier(self):
+        """
+        information about zerotier id
+        :return: 
+        """
         return self._zerotier
 
     def raw(self, command, arguments, queue=None, max_time=None, stream=False):
@@ -781,6 +888,11 @@ class ContainerManager:
 
     class ContainerResponse(Response):
         def get(self, timeout=None):
+            """
+            Get container ID
+            :param timeout: client side timeout in seconds (for the container ID to return)
+            :return: int
+            """
             result = super().get(timeout)
             if result.state != 'SUCCESS':
                 raise Exception('failed to create container: %s' % result.data)
@@ -902,6 +1014,14 @@ class IPManager:
             self._client = client
 
         def add(self, name, hwaddr=None):
+            """
+            Add bridge with given name and optional hardware address
+            
+            For more advanced bridge options please check the `bridge` manager.
+            :param name: bridge name
+            :param hwaddr: mac address (str)
+            :return: 
+            """
             args = {
                 'name': name,
                 'hwaddr': hwaddr,
@@ -910,6 +1030,11 @@ class IPManager:
             return self._client.json("ip.bridge.add", args)
 
         def delete(self, name):
+            """
+            Delete bridge with given name 
+            :param name: bridge name to delete
+            :return: 
+            """
             args = {
                 'name': name,
             }
@@ -917,6 +1042,12 @@ class IPManager:
             return self._client.json("ip.bridge.del", args)
 
         def addif(self, name, inf):
+            """
+            Add interface to bridge
+            :param name: bridge name
+            :param inf: interface name to add
+            :return: 
+            """
             args = {
                 'name': name,
                 'inf': inf,
@@ -925,6 +1056,12 @@ class IPManager:
             return self._client.json('ip.bridge.addif', args)
 
         def delif(self, name, inf):
+            """
+            Delete interface from bridge
+            :param name: bridge name
+            :param inf: interface to remove
+            :return: 
+            """
             args = {
                 'name': name,
                 'inf': inf,
@@ -937,18 +1074,37 @@ class IPManager:
             self._client = client
 
         def up(self, link):
+            """
+            Set interface state to UP
+            
+            :param link: link/interface name
+            :return: 
+            """
             args = {
                 'name': link,
             }
             return self._client.json('ip.link.up', args)
 
         def down(self, link):
+            """
+            Set link/interface state to DOWN
+            
+            :param link: link/interface name
+            :return: 
+            """
             args = {
                 'name': link,
             }
             return self._client.json('ip.link.down', args)
 
         def name(self, link, name):
+            """
+            Rename link
+            
+            :param link: link to rename
+            :param name: new name
+            :return: 
+            """
             args = {
                 'name': link,
                 'new': name,
@@ -963,6 +1119,13 @@ class IPManager:
             self._client = client
 
         def add(self, link, ip):
+            """
+            Add IP to link
+            
+            :param link: link
+            :param ip: ip address to add
+            :return: 
+            """
             args = {
                 'name': link,
                 'ip': ip,
@@ -970,6 +1133,13 @@ class IPManager:
             return self._client.json('ip.addr.add', args)
 
         def delete(self, link, ip):
+            """
+            Delete IP from link
+            
+            :param link: link
+            :param ip: ip address to remove
+            :return: 
+            """
             args = {
                 'name': link,
                 'ip': ip,
@@ -977,6 +1147,12 @@ class IPManager:
             return self._client.json('ip.addr.del', args)
 
         def list(self, link):
+            """
+            List IPs of a link
+            
+            :param link: link name
+            :return: 
+            """
             args = {
                 'name': link,
             }
@@ -987,6 +1163,14 @@ class IPManager:
             self._client = client
 
         def add(self, dev, dst, gw=None):
+            """
+            Add a route
+            
+            :param dev: device name
+            :param dst: destination network
+            :param gw: optional gateway
+            :return: 
+            """
             args = {
                 'dev': dev,
                 'dst': dst,
@@ -995,6 +1179,14 @@ class IPManager:
             return self._client.json('ip.route.add', args)
 
         def delete(self, dev, dst, gw=None):
+            """
+            Delete a route
+            
+            :param dev: device name
+            :param dst: destination network
+            :param gw: optional gateway
+            :return: 
+            """
             args = {
                 'dev': dev,
                 'dst': dst,
@@ -1014,18 +1206,34 @@ class IPManager:
 
     @property
     def bridge(self):
+        """
+        Bridge manager
+        :return: 
+        """
         return self._bridge
 
     @property
     def link(self):
+        """
+        Link manager
+        :return: 
+        """
         return self._link
 
     @property
     def addr(self):
+        """
+        Address manager
+        :return: 
+        """
         return self._addr
 
     @property
     def route(self):
+        """
+        Route manager
+        :return: 
+        """
         return self._route
 
 
@@ -1968,7 +2176,7 @@ class Logger:
 
     def reopen(self):
         """
-        Reopen log file
+        Reopen log file (rotate)
         """
         return self._client.json('logger.reopen', {})
 
@@ -2028,12 +2236,6 @@ class Config:
         return self._client.json('config.get', {})
 
 
-class Experimental:
-
-    def __init__(self, client):
-        pass
-
-
 class Client(BaseClient):
 
     def __init__(self, host, port=6379, password="", db=0, ssl=True, timeout=None, testConnectionAttempts=3):
@@ -2055,7 +2257,6 @@ class Client(BaseClient):
         self._disk_manager = DiskManager(self)
         self._btrfs_manager = BtrfsManager(self)
         self._zerotier = ZerotierManager(self)
-        self._experimntal = Experimental(self)
         self._kvm = KvmManager(self)
         self._logger = Logger(self)
         self._nft = Nft(self)
@@ -2072,43 +2273,75 @@ class Client(BaseClient):
             raise RuntimeError("Could not connect to remote host %s" % host)
 
     @property
-    def experimental(self):
-        return self._experimntal
-
-    @property
     def container(self):
+        """
+        Container manager
+        :return: 
+        """
         return self._container_manager
 
     @property
     def bridge(self):
+        """
+        Bridge manager
+        :return: 
+        """
         return self._bridge_manager
 
     @property
     def disk(self):
+        """
+        Disk manager
+        :return: 
+        """
         return self._disk_manager
 
     @property
     def btrfs(self):
+        """
+        Btrfs manager
+        :return: 
+        """
         return self._btrfs_manager
 
     @property
     def zerotier(self):
+        """
+        Zerotier manager
+        :return: 
+        """
         return self._zerotier
 
     @property
     def kvm(self):
+        """
+        KVM manager
+        :return: 
+        """
         return self._kvm
 
     @property
     def logger(self):
+        """
+        Logger manager
+        :return: 
+        """
         return self._logger
 
     @property
     def nft(self):
+        """
+        NFT manager
+        :return: 
+        """
         return self._nft
 
     @property
     def config(self):
+        """
+        Config manager
+        :return: 
+        """
         return self._config
 
     def raw(self, command, arguments, queue=None, max_time=None, stream=False):

--- a/core0/subsys/containers/manager.go
+++ b/core0/subsys/containers/manager.go
@@ -71,7 +71,8 @@ type ContainerCreateArguments struct {
 	Privileged  bool              `json:"privileged"`   //Apply cgroups and capabilities limitations on the container
 	Hostname    string            `json:"hostname"`     //hostname
 	Storage     string            `json:"storage"`      //ardb storage needed for g8ufs mounts.
-	Tags        []string          `json:"tags"`         //for searching containers
+	Tags        core.Tags         `json:"tags"`         //for searching containers
+	Name        string            `json:"name"`         //for searching containers
 }
 
 type ContainerDispatchArguments struct {

--- a/core0/subsys/containers/manager.go
+++ b/core0/subsys/containers/manager.go
@@ -323,6 +323,7 @@ func (m *containerManager) create(cmd *core.Command) (interface{}, error) {
 		return nil, err
 	}
 
+	args.Tags = cmd.Tags
 	if err := args.Validate(); err != nil {
 		return nil, err
 	}

--- a/core0/subsys/containers/manager.go
+++ b/core0/subsys/containers/manager.go
@@ -410,7 +410,9 @@ func (m *containerManager) dispatch(cmd *core.Command) (interface{}, error) {
 		return nil, fmt.Errorf("container does not exist")
 	}
 
-	args.Command.ID = uuid.New()
+	if args.Command.ID == "" {
+		args.Command.ID = uuid.New()
+	}
 
 	if err := m.pushToContainer(cont, &args.Command); err != nil {
 		return nil, err

--- a/core0/subsys/kvm/domain.go
+++ b/core0/subsys/kvm/domain.go
@@ -87,6 +87,11 @@ const (
 	DiskDeviceTypeCDROM DiskDeviceType = "cdrom"
 )
 
+type MetaData struct {
+	XMLName xml.Name `xml:"tags"`
+	Value   string   `xml:",chardata"`
+}
+
 type Devices struct {
 	Emulator   string            `xml:"emulator"`
 	Graphics   []GraphicsDevice  `xml:"graphics"`

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -702,6 +702,7 @@ func (m *kvmManager) create(cmd *core.Command) (interface{}, error) {
 		return nil, err
 	}
 
+	params.Tags = cmd.Tags
 	if err := params.Valid(); err != nil {
 		return nil, err
 	}

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -143,6 +143,7 @@ type CreateParams struct {
 	Media  []Media     `json:"media"`
 	Nics   []Nic       `json:"nics"`
 	Port   map[int]int `json:"port"`
+	Tags   core.Tags   `json:"tags"`
 }
 
 func (c *CreateParams) Valid() error {

--- a/coreX/bootstrap/plugin.go
+++ b/coreX/bootstrap/plugin.go
@@ -38,6 +38,7 @@ func (b *Bootstrap) pluginFactory(plugin *Plugin, fn string) process.ProcessFact
 			StatsInterval:   srcCmd.StatsInterval,
 			MaxTime:         srcCmd.MaxTime,
 			MaxRestart:      srcCmd.MaxRestart,
+			Name:            srcCmd.Name,
 			RecurringPeriod: srcCmd.RecurringPeriod,
 			LogLevels:       srcCmd.LogLevels,
 			Tags:            srcCmd.Tags,

--- a/coreX/bootstrap/plugin.go
+++ b/coreX/bootstrap/plugin.go
@@ -38,7 +38,6 @@ func (b *Bootstrap) pluginFactory(plugin *Plugin, fn string) process.ProcessFact
 			StatsInterval:   srcCmd.StatsInterval,
 			MaxTime:         srcCmd.MaxTime,
 			MaxRestart:      srcCmd.MaxRestart,
-			Name:            srcCmd.Name,
 			RecurringPeriod: srcCmd.RecurringPeriod,
 			LogLevels:       srcCmd.LogLevels,
 			Tags:            srcCmd.Tags,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Zero-OS
 
-Zero-OS is a stateless and lightweight Linux operating system designed for clustered deployments to host virtual machines and containerized applications.
+Zero-OS is a stateless and lightweight Linux operating system, designed for clustered deployments, to host containerized applications and virtual machines.
 
 - Zero-OS is stateless by not needing any locally stored data, not even Zero-OS system files or system configuration
 - Zero-OS is lightweight by only containing the components required to securely run and manage containers and virtual machines
@@ -9,6 +9,4 @@ The core of Zero-OS is 0-core, which is the Zero-OS replacement for systemd.
 
 Interacting with Zero-OS is done by sending commands to 0-core, allowing you to manage disks, set-up networks and run both containers and virtual machines.
 
-All documentation for 0-core is in the [`/docs`](./docs) directory, including a [table of contents](/docs/SUMMARY.md).
-
-In [Getting Started with 0-core](/docs/gettingstarted/README.md) you find the recommended path to quickly get up and running.
+See the [table of contents](/docs/SUMMARY.md) for an overview of all documentation. In [Getting Started with 0-core](/docs/gettingstarted/README.md) you find the recommended path to quickly get up and running.

--- a/docs/monitoring/logging.md
+++ b/docs/monitoring/logging.md
@@ -93,9 +93,11 @@ job = client.system('ping google.com', stream=True)
 job.stream() # this will start printing ping output in real time on screen. Check stream docstr
 ```
 
+Check [Streaming docs](../interacting/streaming.md) for more details
+ 
 ## Subscribers
 Although streams is useful in most cases, sometimes we need to process the output stream of a job
-by multiple `subscribers`, streams support described above has the following pros:
+by multiple `subscribers`, streams support described above has the following cons:
 
 - Only one receiver can listen to job output stream
 - Enabling streams has to be planned a head starting the job with the stream flags, once started

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -157,11 +157,7 @@ class BaseTest(unittest.TestCase):
 
     def create_container(self, root_url, storage=None, nics=[], host_network=False, tags=None):
         container = self.client.container.create(root_url=root_url, storage=storage, host_network=host_network, nics=nics, tags=tags)
-        result = container.get(30)
-        if result.state != 'SUCCESS':
-            raise RuntimeError('failed to create container %s' % result.data)
-        container_id = json.loads(result.data)
-        return container_id
+        return container.get(30)
 
     def get_vm_uuid(self, vm_name):
         vm_list = self.client.kvm.list()


### PR DESCRIPTION
- Allow multiple subscribers to a process log stream 
- Unify the usage of tags across the zero-os primitives (containers, kvm domains, and jobs)