### PR TITLE
KVM refactors

### DIFF
--- a/core0/subsys/kvm/events.go
+++ b/core0/subsys/kvm/events.go
@@ -19,9 +19,11 @@ func (m *kvmManager) handle(conn *libvirt.Connect, domain *libvirt.Domain, event
 	}()
 
 	uuid, _ := domain.GetUUIDString()
+	name, _ := domain.GetName()
 	parts, _ := shlex.Split(event.String())
 	data := map[string]interface{}{
 		"uuid": uuid,
+		"name": name,
 	}
 
 	for _, part := range parts {

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -1380,7 +1380,7 @@ func (m *kvmManager) monitor(cmd *core.Command) (interface{}, error) {
 
 	p := pm.GetManager()
 	for _, info := range infos {
-		uuid, err := info.Domain.GetUUIDString()
+		name, err := info.Domain.GetName()
 		if err != nil {
 			return nil, err
 		}
@@ -1389,13 +1389,13 @@ func (m *kvmManager) monitor(cmd *core.Command) (interface{}, error) {
 			nr := fmt.Sprintf("%d", i)
 			p.Aggregate(
 				pm.AggreagteAverage,
-				"kvm.vcpu.state", float64(vcpu.State), uuid,
+				"kvm.vcpu.state", float64(vcpu.State), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"nr", nr},
 			)
 
 			p.Aggregate(
 				pm.AggreagteAverage,
-				"kvm.vcpu.time", float64(vcpu.Time)/1000000000., uuid,
+				"kvm.vcpu.time", float64(vcpu.Time)/1000000000., name,
 				pm.Tag{"type", "virt"}, pm.Tag{"nr", nr},
 			)
 		}
@@ -1403,25 +1403,25 @@ func (m *kvmManager) monitor(cmd *core.Command) (interface{}, error) {
 		for _, net := range info.Net {
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.net.rxbytes", float64(net.RxBytes), uuid,
+				"kvm.net.rxbytes", float64(net.RxBytes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", net.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.net.rxpackets", float64(net.RxPkts), uuid,
+				"kvm.net.rxpackets", float64(net.RxPkts), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", net.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.net.txbytes", float64(net.TxBytes), uuid,
+				"kvm.net.txbytes", float64(net.TxBytes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", net.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.net.txpackets", float64(net.TxPkts), uuid,
+				"kvm.net.txpackets", float64(net.TxPkts), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", net.Name},
 			)
 		}
@@ -1429,25 +1429,25 @@ func (m *kvmManager) monitor(cmd *core.Command) (interface{}, error) {
 		for _, block := range info.Block {
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.disk.rdbytes", float64(block.RdBytes), uuid,
+				"kvm.disk.rdbytes", float64(block.RdBytes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", block.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.disk.rdtimes", float64(block.RdTimes), uuid,
+				"kvm.disk.rdtimes", float64(block.RdTimes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", block.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.disk.wrbytes", float64(block.WrBytes), uuid,
+				"kvm.disk.wrbytes", float64(block.WrBytes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", block.Name},
 			)
 
 			p.Aggregate(
 				pm.AggreagteDifference,
-				"kvm.disk.wrtimes", float64(block.WrTimes), uuid,
+				"kvm.disk.wrtimes", float64(block.WrTimes), name,
 				pm.Tag{"type", "virt"}, pm.Tag{"name", block.Name},
 			)
 		}


### PR DESCRIPTION
- Add kvm name to kvm.events message.
- Use kvm name instead of uuid in aggregated stats keys.