### PR TITLE
Workaround ledis issue

### DIFF
--- a/core0/main.go
+++ b/core0/main.go
@@ -109,7 +109,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	Splash()
+	if !options.Agent() {
+		Splash()
+	}
 
 	if err := settings.LoadSettings(options.Config()); err != nil {
 		log.Fatal(err)
@@ -123,13 +125,15 @@ func main() {
 		log.Fatalf("\nConfig validation error, please fix and try again.")
 	}
 
-	//Redirect the stdout, and stderr so we make sure we don't lose crashes that terminates
-	//the process.
-	if err := Redirect(LogPath); err != nil {
-		log.Errorf("failed to redirect output streams: %s", err)
-	}
+	if !options.Agent() {
+		//Redirect the stdout, and stderr so we make sure we don't lose crashes that terminates
+		//the process.
+		if err := Redirect(LogPath); err != nil {
+			log.Errorf("failed to redirect output streams: %s", err)
+		}
 
-	HandleRotation()
+		HandleRotation()
+	}
 
 	var config = settings.Settings
 
@@ -153,7 +157,7 @@ func main() {
 
 	logger.ConfigureLogging(sink)
 
-	bs := bootstrap.NewBootstrap()
+	bs := bootstrap.NewBootstrap(options.Agent())
 	bs.First()
 
 	screen.Push(&screen.TextSection{})

--- a/core0/options/options.go
+++ b/core0/options/options.go
@@ -10,11 +10,16 @@ import (
 type AppOptions struct {
 	cfg     string
 	version bool
+	agent   bool
 	Kernel  utils.KernelOptions
 }
 
 func (o *AppOptions) Config() string {
 	return o.cfg
+}
+
+func (o *AppOptions) Agent() bool {
+	return o.agent
 }
 
 func (o *AppOptions) Version() bool {
@@ -28,6 +33,7 @@ func init() {
 	flag.BoolVar(&help, "h", false, "Print this help screen")
 	flag.StringVar(&Options.cfg, "c", "/etc/g8os/zero-os.toml", "Path to config file")
 	flag.BoolVar(&Options.version, "v", false, "Prints version and exit")
+	flag.BoolVar(&Options.agent, "a", false, "Run in agent mode (not init)")
 	flag.Parse()
 
 	printHelp := func() {

--- a/core0/transport/channel.go
+++ b/core0/transport/channel.go
@@ -37,9 +37,13 @@ func (client *channel) String() string {
 }
 
 func (cl *channel) GetNext(queue string, command *pm.Command) error {
-	payload, err := redis.ByteSlices(cl.db.BLPop([][]byte{[]byte(queue)}, 0))
+	payload, err := redis.ByteSlices(cl.db.BLPop([][]byte{[]byte(queue)}, 500*time.Millisecond))
 	if err != nil {
 		return err
+	}
+
+	if payload == nil || len(payload) < 2 {
+		return redis.ErrNil
 	}
 
 	return json.Unmarshal(payload[1], command)

--- a/core0/transport/sink.go
+++ b/core0/transport/sink.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"fmt"
+	"github.com/garyburd/redigo/redis"
 	"github.com/siddontang/ledisdb/config"
 	"github.com/siddontang/ledisdb/ledis"
 	"github.com/siddontang/ledisdb/server"
@@ -127,7 +128,9 @@ func (sink *Sink) process() {
 	for {
 		var command pm.Command
 		err := sink.ch.GetNext(SinkQueue, &command)
-		if err != nil {
+		if err == redis.ErrNil {
+			continue
+		} else if err != nil {
 			log.Errorf("Failed to get next command from (%s): %s", SinkQueue, err)
 			<-time.After(200 * time.Millisecond)
 			continue


### PR DESCRIPTION
Fixes #462

Avoid blocking on ledis queue by giving a timeout instead of 0
this will prevent the radom failure on poping jobs

- Aslo add support to "agent" mode which allows core0 to work
as a service instead of init replacement. This helps in debuggin
kerenl panics on boot.