### PR TITLE
It's illegal to start process with no stdin

### DIFF
--- a/base/pm/systemprocess.go
+++ b/base/pm/systemprocess.go
@@ -126,8 +126,14 @@ func (p *systemProcessImpl) Run() (ch <-chan *stream.Message, err error) {
 		if err != nil {
 			return nil, err
 		}
-		toClose = append(toClose, stdin)
+	} else {
+		stdin, err = os.Open(os.DevNull)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+    toClose = append(toClose, stdin)
 
 	if !p.args.NoOutput {
 		handler := func(m *stream.Message) {


### PR DESCRIPTION
In case no stdin data is given it's better if we pass /dev/null
instead of a closed file