### PR TITLE
Error codes and processes exit codes

### DIFF
--- a/base/pm/error.go
+++ b/base/pm/error.go
@@ -5,25 +5,39 @@ import (
 	"net/http"
 )
 
+var _ RunError = &errorImpl{}
+
 type RunError interface {
-	Code() int
+	Code() uint32
 	Cause() interface{}
 }
 
 type errorImpl struct {
-	code  int
+	code  uint32
 	cause interface{}
+}
+
+func (e *errorImpl) Code() uint32 {
+	return e.code
+}
+
+func (e *errorImpl) Cause() interface{} {
+	return e.cause
 }
 
 func (e *errorImpl) Error() string {
 	return fmt.Sprintf("[%d] %v", e.code, e.cause)
 }
 
-func Error(code int, cause interface{}) error {
+func Error(code uint32, cause interface{}) error {
 	return &errorImpl{code: code, cause: cause}
 }
 
-func BadRequest(cause interface{}) error {
+func NotFoundError(cause interface{}) error {
+	return Error(http.StatusNotFound, cause)
+}
+
+func BadRequestError(cause interface{}) error {
 	return Error(http.StatusBadRequest, cause)
 }
 

--- a/base/pm/error.go
+++ b/base/pm/error.go
@@ -1,0 +1,32 @@
+package pm
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type RunError interface {
+	Code() int
+	Cause() interface{}
+}
+
+type errorImpl struct {
+	code  int
+	cause interface{}
+}
+
+func (e *errorImpl) Error() string {
+	return fmt.Sprintf("[%d] %v", e.code, e.cause)
+}
+
+func Error(code int, cause interface{}) error {
+	return &errorImpl{code: code, cause: cause}
+}
+
+func BadRequest(cause interface{}) error {
+	return Error(http.StatusBadRequest, cause)
+}
+
+func InternalError(cause interface{}) error {
+	return Error(http.StatusInternalServerError, cause)
+}

--- a/base/pm/error.go
+++ b/base/pm/error.go
@@ -26,7 +26,7 @@ func (e *errorImpl) Cause() interface{} {
 }
 
 func (e *errorImpl) Error() string {
-	return fmt.Sprintf("[%d] %v", e.code, e.cause)
+	return fmt.Sprint(e.cause)
 }
 
 func Error(code uint32, cause interface{}) error {
@@ -39,6 +39,18 @@ func NotFoundError(cause interface{}) error {
 
 func BadRequestError(cause interface{}) error {
 	return Error(http.StatusBadRequest, cause)
+}
+
+func ServiceUnavailableError(cause interface{}) error {
+	return Error(http.StatusServiceUnavailable, cause)
+}
+
+func NotAcceptableError(cause interface{}) error {
+	return Error(http.StatusNotAcceptable, cause)
+}
+
+func PreconditionFailedError(cause interface{}) error {
+	return Error(http.StatusPreconditionFailed, cause)
 }
 
 func InternalError(cause interface{}) error {

--- a/base/pm/job.go
+++ b/base/pm/job.go
@@ -240,10 +240,16 @@ loop:
 				go hook.Message(message)
 			}
 
+			//FOR BACKWARD compatibility, we drop the code part from the message meta because watchers
+			//like watchdog and such are not expecting a code part in the meta (yet)
+			code := message.Meta.Code()
+			message.Meta = message.Meta.Base()
+			//END of BACKWARD compatibility code
+
 			//by default, all messages are forwarded to the manager for further processing.
 			r.callback(message)
 			if message.Meta.Is(stream.ExitSuccessFlag | stream.ExitErrorFlag) {
-				jobresult.Code = message.Meta.Code()
+				jobresult.Code = code
 				break loop
 			}
 		}

--- a/base/pm/pm.go
+++ b/base/pm/pm.go
@@ -461,7 +461,7 @@ func System(bin string, args ...string) (*JobResult, error) {
 
 	job := runner.Wait()
 	if job.State != StateSuccess {
-		return job, fmt.Errorf("exited with error (%s): %v", job.State, job.Streams)
+		return job, Error(job.Code, fmt.Errorf("(%s): %v", job.State, job.Streams))
 	}
 
 	return job, nil

--- a/base/pm/result.go
+++ b/base/pm/result.go
@@ -42,7 +42,7 @@ type JobResult struct {
 	Critical  string   `json:"critical,omitempty"`
 	Level     uint16   `json:"level"`
 	State     JobState `json:"state"`
-	Code      int      `json:"code"`
+	Code      uint32   `json:"code"`
 	StartTime int64    `json:"starttime"`
 	Time      int64    `json:"time"`
 	Tags      Tags     `json:"tags"`

--- a/base/pm/result.go
+++ b/base/pm/result.go
@@ -42,6 +42,7 @@ type JobResult struct {
 	Critical  string   `json:"critical,omitempty"`
 	Level     uint16   `json:"level"`
 	State     JobState `json:"state"`
+	Code      int      `json:"code"`
 	StartTime int64    `json:"starttime"`
 	Time      int64    `json:"time"`
 	Tags      Tags     `json:"tags"`

--- a/base/pm/stream/meta_test.go
+++ b/base/pm/stream/meta_test.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/base/pm/stream/meta_test.go
+++ b/base/pm/stream/meta_test.go
@@ -1,0 +1,134 @@
+package stream
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewMeta(t *testing.T) {
+	m := NewMeta(10, Flag(1), Flag(2))
+
+	if ok := assert.Equal(t, uint16(10), m.Level()); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(1))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(2))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(3))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Is(Flag(4))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Assert(10)); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Assert(20)); !ok {
+		t.Fatal()
+	}
+}
+
+func TestNewMetaWithCode(t *testing.T) {
+	m := NewMetaWithCode(100, 10, Flag(1), Flag(2))
+
+	if ok := assert.Equal(t, uint16(10), m.Level()); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(1))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(2))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(3))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Is(Flag(4))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Assert(10)); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Assert(20)); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, uint32(100), m.Code()); !ok {
+		t.Fatal()
+	}
+}
+
+func TestMeta_Set(t *testing.T) {
+	m := NewMeta(10, Flag(1))
+
+	if ok := assert.Equal(t, uint16(10), m.Level()); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(1))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Is(Flag(2))); !ok {
+		t.Fatal()
+	}
+
+	m = m.Set(Flag(2))
+
+	if ok := assert.True(t, m.Is(Flag(2))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(3))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Is(Flag(4))); !ok {
+		t.Fatal()
+	}
+}
+
+func TestNewMeta_Base(t *testing.T) {
+	m := NewMetaWithCode(100, 10, Flag(1), Flag(2))
+	m = m.Base()
+
+	if ok := assert.Equal(t, uint32(0), m.Code()); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, uint16(10), m.Level()); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(1))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(2))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.True(t, m.Is(Flag(3))); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.False(t, m.Is(Flag(4))); !ok {
+		t.Fatal()
+	}
+}

--- a/base/pm/systemprocess.go
+++ b/base/pm/systemprocess.go
@@ -94,7 +94,7 @@ func (p *systemProcessImpl) Run() (ch <-chan *stream.Message, err error) {
 
 	name, err := exec.LookPath(p.args.Name)
 	if err != nil {
-		return nil, err
+		return nil, NotFoundError(err)
 	}
 
 	var env []string
@@ -205,11 +205,16 @@ func (p *systemProcessImpl) Run() (ch <-chan *stream.Message, err error) {
 		//wait for all streams to finish copying
 		wg.Wait()
 		ps.Release()
-		log.Debugf("Process %s exited with state: %d", p.cmd, state.ExitStatus())
-		if state.ExitStatus() == 0 {
-			channel <- stream.MessageExitSuccess
+		code := state.ExitStatus()
+		log.Debugf("Process %s exited with state: %d", p.cmd, code)
+		if code == 0 {
+			channel <- &stream.Message{
+				Meta: stream.NewMeta(stream.LevelStdout, stream.ExitSuccessFlag),
+			}
 		} else {
-			channel <- stream.MessageExitError
+			channel <- &stream.Message{
+				Meta: stream.NewMetaWithCode(uint32(1000+code), stream.LevelStderr, stream.ExitErrorFlag),
+			}
 		}
 	}(channel)
 

--- a/client/go-client/result.go
+++ b/client/go-client/result.go
@@ -57,6 +57,7 @@ type Result struct {
 	Critical  string  `json:"critical,omitempty"`
 	Level     int     `json:"level"`
 	State     State   `json:"state"`
+	Code      uint32  `json:"code"`
 	StartTime int64   `json:"starttime"`
 	Time      int64   `json:"time"`
 	Tags      string  `json:"tags"`

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -105,12 +105,23 @@ class Return:
         streams = self._payload.get('streams', None)
         return streams[1] if streams is not None and len(streams) >= 2 else ''
 
+    @property
+    def code(self):
+        """
+        Exit code of the job, this can be either one of the http codes, of (if the value > 1000)
+        is the exit code of the underlaying process
+        if code > 1000:
+            exit_code = code - 1000
+
+        """
+        return self._payload.get('code', 500)
+
     def __repr__(self):
         return str(self)
 
     def __str__(self):
         tmpl = """\
-        STATE: {state}
+        STATE: {code} {state}
         STDOUT:
         {stdout}
         STDERR:
@@ -119,7 +130,7 @@ class Return:
         {data}
         """
 
-        return textwrap.dedent(tmpl).format(state=self.state, stdout=self.stdout, stderr=self.stderr, data=self.data)
+        return textwrap.dedent(tmpl).format(code=self.code, state=self.state, stdout=self.stdout, stderr=self.stderr, data=self.data)
 
 
 class Response:
@@ -2098,7 +2109,7 @@ class KvmManager:
 
     def prepare_migration_target(self, uuid, nics=None, port=None, tags=None):
         """
-        :param name: Name of the kvm domain that will be migrated 
+        :param name: Name of the kvm domain that will be migrated
         :param port: A dict of host_port: container_port pairs
                        Example:
                         `port={8080: 80, 7000:7000}`
@@ -2399,7 +2410,7 @@ class Logger:
         """
         Set the log level of the g8os
         Note: this level is for messages that ends up on screen or on log file
-        
+
         :param level: the level to be set can be one of ("CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG")
         """
         args = {
@@ -2419,10 +2430,10 @@ class Logger:
         """
         Subscribe to the aggregated log stream. On subscribe a ledis queue will be fed with all running processes
         logs. Always use the returned queue name from this method, even if u specified the queue name to use
-        
+
         Note: it is legal to subscribe to the same queue, but would be a bad logic if two processes are trying to
         read from the same queue.
-        
+
         :param queue: Your unique queue name, otherwise, a one will get generated for your
         :return: queue name to pull from
         """
@@ -2433,7 +2444,7 @@ class Logger:
         """
         Unsubscribe will kill the queue on node zero, further reading on that queue will just get what has been
         queued before calling unsubscribe, after that reading on that queue will not return anything.
-        
+
         :param queue: Queue name as returned from self.subscribe
         :return:
         """

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -25,6 +25,16 @@ class JobNotFound(Exception):
     pass
 
 
+class ResultException(Exception):
+    def __init__(self, msg, code=0):
+        super().__init__(msg)
+        self._code = code
+
+    @property
+    def code(self):
+        return self._code
+
+
 class Return:
 
     def __init__(self, payload):
@@ -261,6 +271,7 @@ class Response:
             maxwait -= 10
         raise Timeout()
 
+
 class JSONResponse(Response):
     def __init__(self, response):
         super().__init__(response._client, response.id)
@@ -274,9 +285,9 @@ class JSONResponse(Response):
         """
         result = super().get(timeout)
         if result.state != 'SUCCESS':
-            raise Exception('failed to create container: %s' % result.data)
+            raise ResultException(result.data, result.code)
         if result.level != 20:
-            raise Exception('not a json response')
+            raise ResultException('not a json response: %d' % result.level, 406)
 
         return json.loads(result.data)
 


### PR DESCRIPTION
Due too the type of abstraction implemented, the only way a process can communicate up to it's `Job` is via messages. I overloaded the message metadata to include 'code' which is usually not set until the process exits, or the method calls return.

Internally a new Error type is introduced which holds a `code`. We will try to stick to http error codes to make it either to 0-orchestrator to forward back the code without much processing. 

Exit codes of system processes on the other hand, will be added to `1000`.
