### PR TITLE
Use the CURRENT flag instead of LIVE

### DIFF
--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -1000,7 +1000,8 @@ func (m *kvmManager) detachDevice(uuid, xml string) error {
 	if err != nil {
 		return fmt.Errorf("couldn't find domain with the uuid %s", uuid)
 	}
-	if err := domain.DetachDeviceFlags(xml, libvirt.DOMAIN_DEVICE_MODIFY_LIVE); err != nil {
+
+	if err := domain.DetachDeviceFlags(xml, libvirt.DOMAIN_DEVICE_MODIFY_FORCE); err != nil {
 		return fmt.Errorf("failed to attach device: %s", err)
 	}
 

--- a/core0/subsys/kvm/manager.go
+++ b/core0/subsys/kvm/manager.go
@@ -1001,7 +1001,7 @@ func (m *kvmManager) detachDevice(uuid, xml string) error {
 		return fmt.Errorf("couldn't find domain with the uuid %s", uuid)
 	}
 
-	if err := domain.DetachDeviceFlags(xml, libvirt.DOMAIN_DEVICE_MODIFY_FORCE); err != nil {
+	if err := domain.DetachDeviceFlags(xml, libvirt.DOMAIN_DEVICE_MODIFY_CURRENT); err != nil {
 		return fmt.Errorf("failed to attach device: %s", err)
 	}
 


### PR DESCRIPTION

Docs:
https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDetachDeviceFlags
https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDeviceModifyFlags

Fixes #470 