### PR TITLE
Internal command should capture all its output

### DIFF
--- a/base/pm/job.go
+++ b/base/pm/job.go
@@ -237,7 +237,7 @@ loop:
 			}
 
 			for _, hook := range r.hooks {
-				go hook.Message(message)
+				hook.Message(message)
 			}
 
 			//FOR BACKWARD compatibility, we drop the code part from the message meta because watchers

--- a/base/pm/runnerhook.go
+++ b/base/pm/runnerhook.go
@@ -1,6 +1,7 @@
 package pm
 
 import (
+	"bytes"
 	"github.com/zero-os/0-core/base/pm/stream"
 	"regexp"
 	"sync"
@@ -97,4 +98,27 @@ func (h *MatchHook) Message(msg *stream.Message) {
 			h.p = nil
 		})
 	}
+}
+
+type StreamHook struct {
+	NOOPHook
+	Stdout bytes.Buffer
+	Stderr bytes.Buffer
+}
+
+func (h *StreamHook) append(buf *bytes.Buffer, msg *stream.Message) {
+	if buf.Len() > 0 {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(msg.Message)
+}
+
+func (h *StreamHook) Message(msg *stream.Message) {
+	if msg.Meta.Level() == stream.LevelStdout {
+		h.append(&h.Stdout, msg)
+	} else if msg.Meta.Level() == stream.LevelStderr {
+		h.append(&h.Stderr, msg)
+	}
+
+	//ignore otherwise.
 }


### PR DESCRIPTION
Using a job hook, we can intercet and buffer all job output
for usage in internal commands where catpuring the full output is important
that's beside the job internal buffer which is limited to only 100 lines.

This means that calling cl.system('command') will return only 100 lines for
each of stdout, and stderr. while doing the same in core0 side (for internal commands)
will capture the full output for further processing.

Fixes #509 