### PR TITLE
Avoid libvirt when compiling kvm on ARM plateform

### DIFF
--- a/apps/core0/subsys/kvm/domain.go
+++ b/apps/core0/subsys/kvm/domain.go
@@ -1,3 +1,5 @@
+// +build amd64
+
 package kvm
 
 import "encoding/xml"

--- a/apps/core0/subsys/kvm/events.go
+++ b/apps/core0/subsys/kvm/events.go
@@ -1,3 +1,5 @@
+// +build amd64
+
 package kvm
 
 import (

--- a/apps/core0/subsys/kvm/manager.go
+++ b/apps/core0/subsys/kvm/manager.go
@@ -1,3 +1,5 @@
+// +build amd64
+
 package kvm
 
 import (

--- a/apps/core0/subsys/kvm/manager_arm.go
+++ b/apps/core0/subsys/kvm/manager_arm.go
@@ -1,4 +1,5 @@
 // +build arm
+// CC=armv6j-hardfloat-linux-gnueabi-gcc CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-rpath -Wl,/lib" GOOS=linux GOARCH=arm GOARM=6 go build
 
 package kvm
 

--- a/apps/core0/subsys/kvm/manager_arm.go
+++ b/apps/core0/subsys/kvm/manager_arm.go
@@ -1,0 +1,19 @@
+// +build arm
+
+package kvm
+
+import (
+	"github.com/op/go-logging"
+	"github.com/zero-os/0-core/apps/core0/screen"
+	"github.com/zero-os/0-core/apps/core0/subsys/containers"
+)
+
+var (
+	log = logging.MustGetLogger("kvm")
+)
+
+func KVMSubsystem(conmgr containers.ContainerManager, cell *screen.RowCell) error {
+	log.Errorf("kvm disabled on arm")
+	return nil
+}
+

--- a/apps/core0/subsys/kvm/network.go
+++ b/apps/core0/subsys/kvm/network.go
@@ -1,3 +1,5 @@
+// +build amd64
+
 package kvm
 
 import (


### PR DESCRIPTION
There is no goal to support KVM subsystem on ARM platform, this add a clean way to skip it without breaking compatibility.