### PR TITLE
logging

### DIFF
--- a/apps/redis-proxy/main.go
+++ b/apps/redis-proxy/main.go
@@ -35,6 +35,20 @@ func main() {
 			Value: "/var/run/redis.sock",
 			Usage: "redis unix socket to proxy",
 		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "enable debug logging",
+		},
+	}
+
+	app.Before = func(ctx *cli.Context) error {
+		if ctx.GlobalBool("debug") {
+			logging.SetLevel(logging.DEBUG, "")
+		} else {
+			logging.SetLevel(logging.INFO, "")
+		}
+
+		return nil
 	}
 
 	app.Action = func(ctx *cli.Context) error {

--- a/base/pm/extensionprocess.go
+++ b/base/pm/extensionprocess.go
@@ -3,9 +3,10 @@ package pm
 import (
 	"encoding/json"
 	"fmt"
+	"syscall"
+
 	"github.com/zero-os/0-core/base/pm/stream"
 	"github.com/zero-os/0-core/base/utils"
-	"syscall"
 )
 
 type extensionProcess struct {
@@ -25,7 +26,6 @@ func extensionProcessFactory(exe string, dir string, args []string, env map[stri
 		if err := json.Unmarshal(*cmd.Arguments, &input); err != nil {
 			log.Errorf("Failed to load extension command arguments: %s", err)
 		}
-		log.Debugf("rececived arguments for extension are: %v", input)
 
 		if stdin, ok := input["stdin"]; ok {
 			switch in := stdin.(type) {

--- a/base/pm/systemprocess.go
+++ b/base/pm/systemprocess.go
@@ -178,7 +178,6 @@ func (p *systemProcessImpl) Run() (ch <-chan *stream.Message, err error) {
 		},
 	}
 
-	log.Debugf("system: %s", p.args)
 	var ps *os.Process
 	args := []string{name}
 	args = append(args, p.args.Args...)


### PR DESCRIPTION
- set redis-proxy debug level to INFO by default
- remove logging of the arguments of the core.system call (and core.bash)