### PR TITLE
Set hostname during DHCP request

### DIFF
--- a/apps/core0/bootstrap/network/dhcp.go
+++ b/apps/core0/bootstrap/network/dhcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pborman/uuid"
 	"github.com/zero-os/0-core/base/pm"
+	"io/ioutil"
 )
 
 const (
@@ -17,7 +18,23 @@ func init() {
 type dhcpProtocol struct {
 }
 
+func (d *dhcpProtocol) getZerotierId() (string, error) {
+	bytes, err := ioutil.ReadFile("/tmp/zt/identity.public")
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes)[0:10], nil
+}
+
 func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
+	hostid := "zero-os"
+
+	ztid, err := d.getZerotierId()
+	if err == nil {
+		hostid = fmt.Sprintf("zero-os-%s", ztid)
+	}
+
 	cmd := &pm.Command{
 		ID:      uuid.New(),
 		Command: pm.CommandSystem,
@@ -31,7 +48,9 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 					"-A", "3", //wait 3 seconds between each trial
 					"--now",  //exit if failed after consuming all the trials (otherwise stay alive)
 					"--quit", //quit once the lease is obtained
-					"-s", "/usr/share/udhcp/simple.script"},
+					"-s", "/usr/share/udhcp/simple.script",
+					"-x", "hostname", hostid,
+				},
 			},
 		),
 	}

--- a/apps/core0/bootstrap/network/dhcp.go
+++ b/apps/core0/bootstrap/network/dhcp.go
@@ -28,11 +28,11 @@ func (d *dhcpProtocol) getZerotierId() (string, error) {
 }
 
 func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
-	hostid := "zero-os"
+	hostid := "hostname:zero-os"
 
 	ztid, err := d.getZerotierId()
 	if err == nil {
-		hostid = fmt.Sprintf("zero-os-%s", ztid)
+		hostid = fmt.Sprintf("hostname:zero-os-%s", ztid)
 	}
 
 	cmd := &pm.Command{
@@ -49,7 +49,7 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 					"--now",  //exit if failed after consuming all the trials (otherwise stay alive)
 					"--quit", //quit once the lease is obtained
 					"-s", "/usr/share/udhcp/simple.script",
-					"-x", "hostname", hostid,
+					"-x", hostid, //set hostname on dhcp request
 				},
 			},
 		),

--- a/apps/core0/conf/zerotier.toml
+++ b/apps/core0/conf/zerotier.toml
@@ -4,6 +4,7 @@
 [startup."zerotier-init"]
 name = "core.system"
 running_delay = -1
+after = ["init"]
 
 [startup."zerotier-init".args]
 name = "ztid"
@@ -11,7 +12,7 @@ args = ["-out", "/tmp/zt"]
 
 [startup.zerotier]
 name = "core.system"
-after = ["zerotier-init"]
+after = ["net", "zerotier-init"]
 protected = true
 
 [startup.zerotier.args]


### PR DESCRIPTION
Set hostname field on dhcp request. By default, it will be `zero-os`, if the zerotier id was generated (which should be the case), the zerotier id is added (eg: `zero-os-d932dd25c4`) which make it lot easier to find a node based on dhcp server clients list.

This closes #587 