### PR TITLE
DMIDecode primitive support

### DIFF
--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -145,7 +145,8 @@ func dmidecodeRunAndParse(cmd *pm.Command) (interface{}, error) {
 			if arg < 0 && arg > 42 {
 				return nil, fmt.Errorf("Invalid type number %d", arg)
 			}
-			cmdargs = append(cmdargs, fmt.Sprintf(" -t %d", arg))
+			cmdargs = append(cmdargs, "-t")
+			cmdargs = append(cmdargs, fmt.Sprintf("%d", arg))
 		}
 		result, err := pm.System(cmdbin, cmdargs...)
 

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -131,7 +131,6 @@ var dmiKeywords = map[string]bool{
 	"slot":      true,
 }
 
-var sectionRegex = regexp.MustCompile("(?ms:Handle .+?\n\n)")
 var dmiTypeRegex = regexp.MustCompile("DMI type ([0-9]+)")
 var kvRegex = regexp.MustCompile("(.+?):(.*)")
 
@@ -181,11 +180,6 @@ func dmidecodeRunAndParse(cmd *pm.Command) (interface{}, error) {
 // DMITypeToString returns string representation of DMIType t
 func DMITypeToString(t DMIType) string {
 	return dmitypeToString[t]
-}
-
-// section starts with handle until it reaches 2 new lines.
-func getSections(input string) []string {
-	return sectionRegex.FindAllString(input, -1)
 }
 
 // Extract the DMI type from the handleline.

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -182,7 +182,7 @@ type DMISection struct {
 
 // DMI represents a lists of DMISections parsed from dmidecode output.
 type DMI struct {
-	Sections []DMISection `json:"sections"`
+	Sections map[string]DMISection `json:"sections"`
 }
 
 /*
@@ -245,13 +245,14 @@ func parseDMISection(section string) DMISection {
 // ParseDMI Parses dmidecode output into DMI structure
 func ParseDMI(input string) (DMI, error) {
 	dmi := DMI{}
+	dmi.Sections = make(map[string]DMISection)
 	sections := getSections(input)
 	if len(sections) == 0 {
 		return DMI{}, fmt.Errorf("Couldn't parse valid dmi sections from input")
 	}
 	for _, section := range sections {
 		dmisec := parseDMISection(section)
-		dmi.Sections = append(dmi.Sections, dmisec)
+		dmi.Sections[dmisec.Title] = dmisec
 	}
 	return dmi, nil
 }

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -26,7 +26,7 @@ k: [v]
 		...
 	]
 */
-type DMI = map[string]DMISection
+type DMI map[string]DMISection
 
 const (
 	DMITypeBIOS DMIType = iota

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -1,0 +1,229 @@
+package builtin
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+//DMIType (allowed types 0 -> 42)
+type DMIType int
+
+const (
+	DMITypeBIOS DMIType = iota
+	DMITypeSystem
+	DMITypeBaseboard
+	DMITypeChassis
+	DMITypeProcessor
+	DMITypeMemoryController
+	DMITypeMemoryModule
+	DMITypeCache
+	DMITypePortConnector
+	DMITypeSystemSlots
+	DMITypeOnBoardDevices
+	DMITypeOEMSettings
+	DMITypeSystemConfigurationOptions
+	DMITypeBIOSLanguage
+	DMITypeGroupAssociations
+	DMITypeSystemEventLog
+	DMITypePhysicalMemoryArray
+	DMITypeMemoryDevice
+	DMIType32BitMemoryError
+	DMITypeMemoryArrayMappedAddress
+	DMITypeMemoryDeviceMappedAddress
+	DMITypeBuiltinPointingDevice
+	DMITypePortableBattery
+	DMITypeSystemReset
+	DMITypeHardwareSecurity
+	DMITypeSystemPowerControls
+	DMITypeVoltageProbe
+	DMITypeCoolingDevice
+	DMITypeTemperatureProbe
+	DMITypeElectricalCurrentProbe
+	DMITypeOutOfBandRemoteAccess
+	DMITypeBootIntegrityServices
+	DMITypeSystemBoot
+	DMIType64BitMemoryError
+	DMITypeManagementDevice
+	DMITypeManagementDeviceComponent
+	DMITypeManagementDeviceThresholdData
+	DMITypeMemoryChannel
+	DMITypeIPMIDevice
+	DMITypePowerSupply
+	DMITypeAdditionalInformation
+	DMITypeOnboardDevicesExtendedInformation
+	DMITypeManagementControllerHostInterface
+)
+
+var dmitypeToString = map[DMIType]string{
+	DMITypeBIOS:                              "BIOS",
+	DMITypeSystem:                            "System",
+	DMITypeBaseboard:                         "Baseboard",
+	DMITypeChassis:                           "Chassis",
+	DMITypeProcessor:                         "Processor",
+	DMITypeMemoryController:                  "MemoryController",
+	DMITypeMemoryModule:                      "MemoryModule",
+	DMITypeCache:                             "Cache",
+	DMITypePortConnector:                     "PortConnector",
+	DMITypeSystemSlots:                       "SystemSlots",
+	DMITypeOnBoardDevices:                    "OnBoardDevices",
+	DMITypeOEMSettings:                       "OEMSettings",
+	DMITypeSystemConfigurationOptions:        "SystemConfigurationOptions",
+	DMITypeBIOSLanguage:                      "BIOSLanguage",
+	DMITypeGroupAssociations:                 "GroupAssociations",
+	DMITypeSystemEventLog:                    "SystemEventLog",
+	DMITypePhysicalMemoryArray:               "PhysicalMemoryArray",
+	DMITypeMemoryDevice:                      "MemoryDevice",
+	DMIType32BitMemoryError:                  "32BitMemoryError",
+	DMITypeMemoryArrayMappedAddress:          "MemoryArrayMappedAddress",
+	DMITypeMemoryDeviceMappedAddress:         "MemoryDeviceMappedAddress",
+	DMITypeBuiltinPointingDevice:             "BuiltinPointingDevice",
+	DMITypePortableBattery:                   "PortableBattery",
+	DMITypeSystemReset:                       "SystemReset",
+	DMITypeHardwareSecurity:                  "HardwareSecurity",
+	DMITypeSystemPowerControls:               "SystemPowerControls",
+	DMITypeVoltageProbe:                      "VoltageProbe",
+	DMITypeCoolingDevice:                     "CoolingDevice",
+	DMITypeTemperatureProbe:                  "TempratureProbe",
+	DMITypeElectricalCurrentProbe:            "ElectricalCurrentProbe",
+	DMITypeOutOfBandRemoteAccess:             "OutOfBandRemoteAccess",
+	DMITypeBootIntegrityServices:             "BootIntegrityServices",
+	DMITypeSystemBoot:                        "SystemBoot",
+	DMIType64BitMemoryError:                  "64BitMemoryError",
+	DMITypeManagementDevice:                  "ManagementDevice",
+	DMITypeManagementDeviceComponent:         "ManagementDeviceComponent",
+	DMITypeManagementDeviceThresholdData:     "ManagementThresholdData",
+	DMITypeMemoryChannel:                     "MemoryChannel",
+	DMITypeIPMIDevice:                        "IPMIDevice",
+	DMITypePowerSupply:                       "PowerSupply",
+	DMITypeAdditionalInformation:             "AdditionalInformation",
+	DMITypeOnboardDevicesExtendedInformation: "OnboardDeviceExtendedInformation",
+	DMITypeManagementControllerHostInterface: "ManagementControllerHostInterface",
+}
+
+// DMITypeToString returns string representation of DMIType t
+func DMITypeToString(t DMIType) string {
+	return dmitypeToString[t]
+}
+
+func getSections(input string) []string {
+	sectionParams := regexp.MustCompile("(?ms:Handle .+?\n\n)")
+	return sectionParams.FindAllString(input, -1)
+}
+func getDMITypeFromHandleLine(line string) (DMIType, error) {
+	dmitypepat := regexp.MustCompile("DMI type ([0-9]+)")
+	m := dmitypepat.FindStringSubmatch(line)
+	if len(m) == 2 {
+		t, err := strconv.Atoi(m[1])
+		return DMIType(t), err
+	}
+	return 0, fmt.Errorf("Couldn't find dmitype in handleline %s", line)
+
+}
+
+func isListProperty(lidx int, lines []string) bool {
+	lvl := getLineLevel(lines[lidx])
+	nxtline := lines[lidx+1]
+	if strings.TrimSpace(nxtline) == "" {
+		return false
+	}
+	nxtlvl := getLineLevel(lines[lidx+1])
+	return nxtlvl != lvl
+}
+
+func whereListPropertyEnds(startIdx int, lines []string) int {
+	lvl := getLineLevel(lines[startIdx])
+	for i := startIdx + 1; i < len(lines); i++ {
+		current := lines[i]
+		if lvl == getLineLevel(current) {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+// Property represents a key value pair with optional list of items
+type Property struct {
+	Key   string   `json:"key"`
+	Val   string   `json:"value"`
+	Items []string `json:"items,omitempty"`
+}
+
+// DMISection represents a complete section like BIOS or Baseboard
+type DMISection struct {
+	HandleLine string     `json:"handleline"`
+	Title      string     `json:"title"`
+	TypeStr    string     `json:"typestr,omitempty"`
+	Type       DMIType    `json:"typenum"`
+	Properties []Property `json:"properties,omitempty"`
+}
+
+// DMI represents a lists of DMISections parsed from dmidecode output.
+type DMI struct {
+	Sections []DMISection `json:"sections"`
+}
+
+func propertyFromLine(line string) (Property, error) {
+	kvpat := regexp.MustCompile("(.+?):(.*)")
+	m := kvpat.FindStringSubmatch(line)
+	if len(m) == 3 {
+		k, v := strings.TrimSpace(m[1]), strings.TrimSpace(m[2])
+		return Property{Key: k, Val: v}, nil
+	} else if len(m) == 2 {
+		k := strings.TrimSpace(m[1])
+		return Property{Key: k, Val: ""}, nil
+	} else {
+		return Property{}, fmt.Errorf("Couldnt find key value pair on the line %s", line)
+	}
+}
+func parseDMISection(section string) DMISection {
+	dmi := DMISection{}
+	lines := strings.Split(section, "\n")
+	dmi.HandleLine = lines[0]
+	if t, err := getDMITypeFromHandleLine(lines[0]); err == nil {
+		dmi.Type = t
+		dmi.TypeStr = dmitypeToString[dmi.Type]
+	}
+	dmi.Title = lines[1]
+
+	propertieslines := lines[2:]
+	for i := 0; i < len(propertieslines); i++ {
+		l := propertieslines[i]
+		if p, err := propertyFromLine(l); err == nil {
+			if isListProperty(i, propertieslines) {
+				endidx := whereListPropertyEnds(i, propertieslines)
+				subpropslines := propertieslines[i+1 : endidx]
+				for _, item := range subpropslines {
+					if trimmeditem := strings.TrimSpace(item); trimmeditem != "" {
+						p.Items = append(p.Items, strings.TrimSpace(item))
+					}
+				}
+				i = endidx //skip till the end
+			}
+			dmi.Properties = append(dmi.Properties, p)
+		}
+	}
+	return dmi
+}
+
+// ParseDMI Parses dmidecode output into DMI structure
+func ParseDMI(input string) DMI {
+	dmi := DMI{}
+	sections := getSections(input)
+	for _, section := range sections {
+		dmisec := parseDMISection(section)
+		dmi.Sections = append(dmi.Sections, dmisec)
+	}
+	return dmi
+}
+
+func getLineLevel(line string) int {
+	for i, c := range line {
+		if !unicode.IsSpace(c) {
+			return i
+		}
+	}
+	return 0
+}

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -148,23 +148,21 @@ func dmidecodeRunAndParse(cmd *pm.Command) (interface{}, error) {
 	}
 	output := ""
 	var cmdargs []string
-	if len(args.Types) > 0 {
-		for _, arg := range args.Types {
-			switch iarg := arg.(type) {
-			case float64:
-				num := int(iarg)
-				if num < 0 || num > 42 {
-					return nil, pm.BadRequestError(fmt.Errorf("type out of range: %v", num))
-				}
-			case string:
-				if exists := dmiKeywords[iarg]; !exists {
-					return nil, fmt.Errorf("invalid keyword %v", arg)
-				}
-			default:
-				return nil, pm.BadRequestError(fmt.Errorf("invalid type: %v(%T)", iarg, iarg))
+	for _, arg := range args.Types {
+		switch iarg := arg.(type) {
+		case float64:
+			num := int(iarg)
+			if num < 0 || num > 42 {
+				return nil, pm.BadRequestError(fmt.Errorf("type out of range: %v", num))
 			}
-			cmdargs = append(cmdargs, "-t", fmt.Sprintf("%v", arg))
+		case string:
+			if exists := dmiKeywords[iarg]; !exists {
+				return nil, fmt.Errorf("invalid keyword %v", arg)
+			}
+		default:
+			return nil, pm.BadRequestError(fmt.Errorf("invalid type: %v(%T)", iarg, iarg))
 		}
+		cmdargs = append(cmdargs, "-t", fmt.Sprintf("%v", arg))
 	}
 
 	result, err := pm.System(cmdbin, cmdargs...)

--- a/apps/core0/builtin/dmi.go
+++ b/apps/core0/builtin/dmi.go
@@ -150,7 +150,7 @@ func isListProperty(lidx int, lines []string) bool {
 		return false
 	}
 	nxtlvl := getLineLevel(lines[lidx+1])
-	return nxtlvl != lvl
+	return nxtlvl > lvl
 }
 
 // searches where the lines dedent again indicating the end of the property.
@@ -234,7 +234,7 @@ func parseDMISection(section string) DMISection {
 						p.Items = append(p.Items, strings.TrimSpace(item))
 					}
 				}
-				i = endidx //skip till the end
+				i = endidx - 1 //skip the beginning of the new property (i will increment afterwards.)
 			}
 			dmi.Properties[k] = p
 		}

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -100,6 +100,7 @@ Handle 0x0011, DMI type 32, 20 bytes
 System Boot Information
 		Status: No errors detected
 
+
 	`
 	sample4 = `
 # dmidecode 3.1
@@ -188,8 +189,6 @@ Processor Information
 		Thread Count: 4
 		Characteristics:
 				64-bit capable
-	
-
 
 	`
 )
@@ -269,8 +268,10 @@ var processorTests = map[string]string {
 }
 
 func TestParseSectionSimple(t *testing.T) {
-	dmi := ParseDMI(sample1)
-
+	dmi, err := ParseDMI(sample1)
+	if ok:= assert.Equal(t, nil, err); !ok {
+		t.Fatal()
+	}
 	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
 	}
@@ -289,7 +290,10 @@ func TestParseSectionSimple(t *testing.T) {
 
 }
 func TestParseSectionWithListProperty(t *testing.T) {
-	dmi := ParseDMI(sample2)
+	dmi, err := ParseDMI(sample2)
+	if ok:= assert.Equal(t, nil, err); !ok {
+		t.Fatal()
+	}
 
 	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
@@ -314,7 +318,10 @@ func TestParseSectionWithListProperty(t *testing.T) {
 }
 
 func TestParseMultipleSectionsSimple(t *testing.T) {
-	dmi := ParseDMI(sample3)
+	dmi, err := ParseDMI(sample3)
+	if ok:= assert.Equal(t, nil, err); !ok {
+		t.Fatal()
+	}
 	if ok := assert.Equal(t, len(dmi), 4); !ok {
 		t.Fatal()
 	}
@@ -358,7 +365,10 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 
 }
 func TestParseMultipleSectionsWithListProperties(t *testing.T) {
-	dmi := ParseDMI(sample4)
+	dmi, err := ParseDMI(sample4)
+	if ok:= assert.Equal(t, nil, err); !ok {
+		t.Fatal()
+	}
 	if ok := assert.Equal(t, 2, len(dmi)); !ok {
 		t.Fatal()
 	}

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -197,10 +197,8 @@ Processor Information
 )
 
 func TestParseSectionSimple(t *testing.T) {
-	dmi, err := ParseDMI(sample1)
-	if ok := assert.Equal(t, err, nil); !ok {
-		t.Fatal()
-	}
+	dmi := ParseDMI(sample1)
+
 	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
 	}
@@ -216,10 +214,8 @@ func TestParseSectionSimple(t *testing.T) {
 
 }
 func TestParseSectionWithListProperty(t *testing.T) {
-	dmi, err := ParseDMI(sample2)
-	if ok := assert.Equal(t, err, nil); !ok {
-		t.Fatal()
-	}
+	dmi := ParseDMI(sample2)
+
 	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
 	}
@@ -240,10 +236,7 @@ func TestParseSectionWithListProperty(t *testing.T) {
 }
 
 func TestParseMultipleSectionsSimple(t *testing.T) {
-	dmi, err := ParseDMI(sample3)
-	if ok := assert.Equal(t, err, nil); !ok {
-		t.Fatal()
-	}
+	dmi := ParseDMI(sample3)
 	if ok := assert.Equal(t, len(dmi), 4); !ok {
 		t.Fatal()
 	}
@@ -269,10 +262,7 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 	}
 }
 func TestParseMultipleSectionsWithListProperties(t *testing.T) {
-	dmi, err := ParseDMI(sample4)
-	if ok := assert.Equal(t, err, nil); !ok {
-		t.Fatal()
-	}
+	dmi := ParseDMI(sample4)
 	if ok := assert.Equal(t, 2, len(dmi)); !ok {
 		t.Fatal()
 	}

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -1,9 +1,7 @@
 package builtin
 
 import (
-	"fmt"
 	"testing"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -195,6 +193,80 @@ Processor Information
 
 	`
 )
+var	biosInfoTests = map[string]string{
+		"Vendor": "LENOVO",
+		"Version": "29CN40WW(V2.17)",
+		"Release Date": "04/13/2011",
+		"ROM Size": "2048 kB",
+		"Characteristics": "",
+		"BIOS Revision": "1.40",
+}
+var sysInfoTests = map[string]string{
+		"Manufacturer": "LENOVO",
+		"Product Name": "20042",
+		"Version": "Lenovo G560",
+		"Serial Number": "2677240001087",
+		"UUID": "CB3E6A50-A77B-E011-88E9-B870F4165734",
+		"Wake-up Type": "Power Switch",
+		"SKU Number" : "Calpella_CRB",
+		"Family": "Intel_Mobile",
+}
+
+var sysConfigurationTests = map[string]string{
+	"Option 1": "String1 for Type12 Equipment Manufacturer",
+	"Option 2": "String2 for Type12 Equipment Manufacturer",
+	"Option 3": "String3 for Type12 Equipment Manufacturer",
+	"Option 4": "String4 for Type12 Equipment Manufacturer",
+}
+
+var sysEventLogTests =  map[string]string{
+	"Area Length": "0 bytes",
+	"Header Start Offset": "0x0000",
+	"Data Start Offset": "0x0000",
+	"Access Method": "General-purpose non-volatile data functions",
+	"Access Address": "0x0000",
+	"Status": "Valid, Not Full",
+	"Change Token": "0x12345678",
+	"Header Format": "OEM-specific",
+	"Supported Log Type Descriptors": "3",
+	"Descriptor 1": "POST memory resize",
+	"Data Format 1": "None",
+	"Descriptor 2": "POST error",
+	"Data Format 2": "POST results bitmap",
+	"Descriptor 3": "Log area reset/cleared",
+	"Data Format 3": "None",
+}
+
+var sysBootTests = map[string]string {
+	"Status": "No errors detected",
+}
+
+var processorTests = map[string]string {
+		"Socket Designation": "CPU",
+		"Type": "Central Processor",
+		"Family": "Core 2 Duo",
+		"Manufacturer": "Intel(R) Corporation",
+		"ID": "55 06 02 00 FF FB EB BF",
+		"Signature": "Type 0, Family 6, Model 37, Stepping 5",
+		"Flags": "",
+		"Version": "Intel(R) Core(TM) i3 CPU       M 370  @ 2.40GHz",
+		"Voltage": "0.0 V",
+		"External Clock": "1066 MHz",
+		"Max Speed": "2400 MHz",
+		"Current Speed": "2399 MHz",
+		"Status": "Populated, Enabled",
+		"Upgrade": "ZIF Socket",
+		"L1 Cache Handle": "0x0030",
+		"L2 Cache Handle": "0x002F",
+		"L3 Cache Handle": "0x002D",
+		"Serial Number": "Not Specified",
+		"Asset Tag": "FFFF",
+		"Part Number": "Not Specified",
+		"Core Count": "2",
+		"Core Enabled": "2",
+		"Thread Count": "4",
+		"Characteristics":"",
+}
 
 func TestParseSectionSimple(t *testing.T) {
 	dmi := ParseDMI(sample1)
@@ -208,8 +280,11 @@ func TestParseSectionSimple(t *testing.T) {
 	if ok := assert.Equal(t, "System Information", dmi["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "2677240001087", dmi["System Information"].Properties["Serial Number"].Val); !ok {
-		t.Fatal()
+
+	for k, v := range sysInfoTests {
+		if ok := assert.Equal(t, v, dmi["System Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
 	}
 
 }
@@ -225,12 +300,15 @@ func TestParseSectionWithListProperty(t *testing.T) {
 	if ok := assert.Equal(t, "BIOS Information", dmi["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "1.40", dmi["BIOS Information"].Properties["BIOS Revision"].Val); !ok {
-		t.Fatal()
-	}
 	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 
 		t.Fatal()
+	}
+
+	for k, v := range biosInfoTests {
+		if ok := assert.Equal(t, v, dmi["BIOS Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
 	}
 
 }
@@ -253,13 +331,31 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 	if ok := assert.Equal(t, 15, len(dmi["System Event Log"].Properties)); !ok {
 		t.Fatal()
 	}
-	fmt.Println("")
-	if ok := assert.Equal(t, "0 bytes", dmi["System Event Log"].Properties["Area Length"].Val); !ok {
-		t.Fatal()
-	}
 	if ok := assert.Equal(t, DMITypeSystemBoot, dmi["System Boot Information"].Type); !ok {
 		t.Fatal()
 	}
+
+	for k, v := range sysInfoTests {
+		if ok := assert.Equal(t, v, dmi["System Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
+	}
+	for k, v := range sysConfigurationTests {
+		if ok := assert.Equal(t, v, dmi["System Configuration Options"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
+	}
+	for k, v := range sysEventLogTests {
+		if ok := assert.Equal(t, v, dmi["System Event Log"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
+	}
+	for k, v := range sysBootTests {
+		if ok := assert.Equal(t, v, dmi["System Boot Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
+	}
+
 }
 func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 	dmi := ParseDMI(sample4)
@@ -276,12 +372,6 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "PCI is supported", dmi["BIOS Information"].Properties["Characteristics"].Items[0]); !ok {
-		t.Fatal()
-	}
-	if ok := assert.Equal(t, "LENOVO", dmi["BIOS Information"].Properties["Vendor"].Val); !ok {
-		t.Fatal()
-	}
 
 	if ok := assert.Equal(t, "Processor Information", dmi["Processor Information"].Title); !ok {
 		t.Fatal()
@@ -291,14 +381,23 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "2", dmi["Processor Information"].Properties["Core Count"].Val); !ok {
-		t.Fatal()
-	}
 
 	if ok := assert.Equal(t, 28, len(dmi["Processor Information"].Properties["Flags"].Items)); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi["Processor Information"].Properties["Flags"].Items[0]); !ok {
 		t.Fatal()
+	}
+
+	for k, v := range biosInfoTests {
+		if ok := assert.Equal(t, v, dmi["BIOS Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		} 
+	}
+
+	for k, v := range processorTests {
+		if ok := assert.Equal(t, v, dmi["Processor Information"].Properties[k].Val); !ok {
+			t.Fatal()
+		}	
 	}
 }

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -201,16 +201,16 @@ func TestParseSectionSimple(t *testing.T) {
 	if ok := assert.Equal(t, err, nil); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
+	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi.Sections["System Information"].Properties)); !ok {
+	if ok := assert.Equal(t, 8, len(dmi["System Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "System Information", dmi.Sections["System Information"].Title); !ok {
+	if ok := assert.Equal(t, "System Information", dmi["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "2677240001087", dmi.Sections["System Information"].Properties["Serial Number"].Val); !ok {
+	if ok := assert.Equal(t, "2677240001087", dmi["System Information"].Properties["Serial Number"].Val); !ok {
 		t.Fatal()
 	}
 
@@ -220,19 +220,19 @@ func TestParseSectionWithListProperty(t *testing.T) {
 	if ok := assert.Equal(t, err, nil); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
+	if ok := assert.Equal(t, 1, len(dmi)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 6, len(dmi.Sections["BIOS Information"].Properties)); !ok {
+	if ok := assert.Equal(t, 6, len(dmi["BIOS Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "BIOS Information", dmi.Sections["BIOS Information"].Title); !ok {
+	if ok := assert.Equal(t, "BIOS Information", dmi["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "1.40", dmi.Sections["BIOS Information"].Properties["BIOS Revision"].Val); !ok {
+	if ok := assert.Equal(t, "1.40", dmi["BIOS Information"].Properties["BIOS Revision"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi.Sections["BIOS Information"].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 
 		t.Fatal()
 	}
@@ -244,27 +244,27 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 	if ok := assert.Equal(t, err, nil); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, len(dmi.Sections), 4); !ok {
+	if ok := assert.Equal(t, len(dmi), 4); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "System Information", dmi.Sections["System Information"].Title); !ok {
+	if ok := assert.Equal(t, "System Information", dmi["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi.Sections["System Information"].Properties)); !ok {
+	if ok := assert.Equal(t, 8, len(dmi["System Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "System Event Log", dmi.Sections["System Event Log"].Title); !ok {
+	if ok := assert.Equal(t, "System Event Log", dmi["System Event Log"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 15, len(dmi.Sections["System Event Log"].Properties)); !ok {
+	if ok := assert.Equal(t, 15, len(dmi["System Event Log"].Properties)); !ok {
 		t.Fatal()
 	}
 	fmt.Println("")
-	if ok := assert.Equal(t, "0 bytes", dmi.Sections["System Event Log"].Properties["Area Length"].Val); !ok {
+	if ok := assert.Equal(t, "0 bytes", dmi["System Event Log"].Properties["Area Length"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, DMITypeSystemBoot, dmi.Sections["System Boot Information"].Type); !ok {
+	if ok := assert.Equal(t, DMITypeSystemBoot, dmi["System Boot Information"].Type); !ok {
 		t.Fatal()
 	}
 }
@@ -273,42 +273,42 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 	if ok := assert.Equal(t, err, nil); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 2, len(dmi.Sections)); !ok {
+	if ok := assert.Equal(t, 2, len(dmi)); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "BIOS Information", dmi.Sections["BIOS Information"].Title); !ok {
+	if ok := assert.Equal(t, "BIOS Information", dmi["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, len(dmi.Sections["BIOS Information"].Properties), 6); !ok {
+	if ok := assert.Equal(t, len(dmi["BIOS Information"].Properties), 6); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi.Sections["BIOS Information"].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "PCI is supported", dmi.Sections["BIOS Information"].Properties["Characteristics"].Items[0]); !ok {
+	if ok := assert.Equal(t, "PCI is supported", dmi["BIOS Information"].Properties["Characteristics"].Items[0]); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "LENOVO", dmi.Sections["BIOS Information"].Properties["Vendor"].Val); !ok {
-		t.Fatal()
-	}
-
-	if ok := assert.Equal(t, "Processor Information", dmi.Sections["Processor Information"].Title); !ok {
+	if ok := assert.Equal(t, "LENOVO", dmi["BIOS Information"].Properties["Vendor"].Val); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, len(dmi.Sections["Processor Information"].Properties), 24); !ok {
+	if ok := assert.Equal(t, "Processor Information", dmi["Processor Information"].Title); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "2", dmi.Sections["Processor Information"].Properties["Core Count"].Val); !ok {
+	if ok := assert.Equal(t, len(dmi["Processor Information"].Properties), 24); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, 28, len(dmi.Sections["Processor Information"].Properties["Flags"].Items)); !ok {
+	if ok := assert.Equal(t, "2", dmi["Processor Information"].Properties["Core Count"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi.Sections["Processor Information"].Properties["Flags"].Items[0]); !ok {
+
+	if ok := assert.Equal(t, 28, len(dmi["Processor Information"].Properties["Flags"].Items)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi["Processor Information"].Properties["Flags"].Items[0]); !ok {
 		t.Fatal()
 	}
 }

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,13 +204,13 @@ func TestParseSectionSimple(t *testing.T) {
 	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi.Sections[0].Properties)); !ok {
+	if ok := assert.Equal(t, 8, len(dmi.Sections["System Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "System Information", dmi.Sections[0].Title); !ok {
+	if ok := assert.Equal(t, "System Information", dmi.Sections["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "2677240001087", dmi.Sections[0].Properties["Serial Number"].Val); !ok {
+	if ok := assert.Equal(t, "2677240001087", dmi.Sections["System Information"].Properties["Serial Number"].Val); !ok {
 		t.Fatal()
 	}
 
@@ -222,16 +223,16 @@ func TestParseSectionWithListProperty(t *testing.T) {
 	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 6, len(dmi.Sections[0].Properties)); !ok {
+	if ok := assert.Equal(t, 6, len(dmi.Sections["BIOS Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "BIOS Information", dmi.Sections[0].Title); !ok {
+	if ok := assert.Equal(t, "BIOS Information", dmi.Sections["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "1.40", dmi.Sections[0].Properties["BIOS Revision"].Val); !ok {
+	if ok := assert.Equal(t, "1.40", dmi.Sections["BIOS Information"].Properties["BIOS Revision"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi.Sections[0].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Equal(t, 18, len(dmi.Sections["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 
 		t.Fatal()
 	}
@@ -247,23 +248,23 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "System Information", dmi.Sections[0].Title); !ok {
+	if ok := assert.Equal(t, "System Information", dmi.Sections["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi.Sections[0].Properties)); !ok {
+	if ok := assert.Equal(t, 8, len(dmi.Sections["System Information"].Properties)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "System Event Log", dmi.Sections[2].Title); !ok {
+	if ok := assert.Equal(t, "System Event Log", dmi.Sections["System Event Log"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 15, len(dmi.Sections[2].Properties)); !ok {
+	if ok := assert.Equal(t, 15, len(dmi.Sections["System Event Log"].Properties)); !ok {
 		t.Fatal()
 	}
-
-	if ok := assert.Equal(t, "0 bytes", dmi.Sections[2].Properties["Area Length"].Val); !ok {
+	fmt.Println("")
+	if ok := assert.Equal(t, "0 bytes", dmi.Sections["System Event Log"].Properties["Area Length"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, DMITypeSystemBoot, dmi.Sections[3].Type); !ok {
+	if ok := assert.Equal(t, DMITypeSystemBoot, dmi.Sections["System Boot Information"].Type); !ok {
 		t.Fatal()
 	}
 }
@@ -276,38 +277,38 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "BIOS Information", dmi.Sections[0].Title); !ok {
+	if ok := assert.Equal(t, "BIOS Information", dmi.Sections["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, len(dmi.Sections[0].Properties), 6); !ok {
+	if ok := assert.Equal(t, len(dmi.Sections["BIOS Information"].Properties), 6); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi.Sections[0].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Equal(t, 18, len(dmi.Sections["BIOS Information"].Properties["Characteristics"].Items)); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "PCI is supported", dmi.Sections[0].Properties["Characteristics"].Items[0]); !ok {
+	if ok := assert.Equal(t, "PCI is supported", dmi.Sections["BIOS Information"].Properties["Characteristics"].Items[0]); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "LENOVO", dmi.Sections[0].Properties["Vendor"].Val); !ok {
-		t.Fatal()
-	}
-
-	if ok := assert.Equal(t, "Processor Information", dmi.Sections[1].Title); !ok {
+	if ok := assert.Equal(t, "LENOVO", dmi.Sections["BIOS Information"].Properties["Vendor"].Val); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, len(dmi.Sections[1].Properties), 24); !ok {
+	if ok := assert.Equal(t, "Processor Information", dmi.Sections["Processor Information"].Title); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, "2", dmi.Sections[1].Properties["Core Count"].Val); !ok {
+	if ok := assert.Equal(t, len(dmi.Sections["Processor Information"].Properties), 24); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, 28, len(dmi.Sections[1].Properties["Flags"].Items)); !ok {
+	if ok := assert.Equal(t, "2", dmi.Sections["Processor Information"].Properties["Core Count"].Val); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi.Sections[1].Properties["Flags"].Items[0]); !ok {
+
+	if ok := assert.Equal(t, 28, len(dmi.Sections["Processor Information"].Properties["Flags"].Items)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi.Sections["Processor Information"].Properties["Flags"].Items[0]); !ok {
 		t.Fatal()
 	}
 }

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -1,0 +1,313 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	sample1 = `
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+		Manufacturer: LENOVO
+		Product Name: 20042
+		Version: Lenovo G560
+		Serial Number: 2677240001087
+		UUID: CB3E6A50-A77B-E011-88E9-B870F4165734
+		Wake-up Type: Power Switch
+		SKU Number: Calpella_CRB
+		Family: Intel_Mobile
+
+	`
+	sample2 = `
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+		Vendor: LENOVO
+		Version: 29CN40WW(V2.17)
+		Release Date: 04/13/2011
+		ROM Size: 2048 kB
+		Characteristics:
+				PCI is supported
+				BIOS is upgradeable
+				BIOS shadowing is allowed
+				Boot from CD is supported
+				Selectable boot is supported
+				EDD is supported
+				Japanese floppy for NEC 9800 1.2 MB is supported (int 13h)
+				Japanese floppy for Toshiba 1.2 MB is supported (int 13h)
+				5.25"/360 kB floppy services are supported (int 13h)
+				5.25"/1.2 MB floppy services are supported (int 13h)
+				3.5"/720 kB floppy services are supported (int 13h)
+				3.5"/2.88 MB floppy services are supported (int 13h)
+				8042 keyboard services are supported (int 9h)
+				CGA/mono video services are supported (int 10h)
+				ACPI is supported
+				USB legacy is supported
+				BIOS boot specification is supported
+				Targeted content distribution is supported
+		BIOS Revision: 1.40
+
+	`
+	sample3 = `
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+		Manufacturer: LENOVO
+		Product Name: 20042
+		Version: Lenovo G560
+		Serial Number: 2677240001087
+		UUID: CB3E6A50-A77B-E011-88E9-B870F4165734
+		Wake-up Type: Power Switch
+		SKU Number: Calpella_CRB
+		Family: Intel_Mobile
+
+Handle 0x000D, DMI type 12, 5 bytes
+System Configuration Options
+		Option 1: String1 for Type12 Equipment Manufacturer
+		Option 2: String2 for Type12 Equipment Manufacturer
+		Option 3: String3 for Type12 Equipment Manufacturer
+		Option 4: String4 for Type12 Equipment Manufacturer
+
+Handle 0x000E, DMI type 15, 29 bytes
+System Event Log
+		Area Length: 0 bytes
+		Header Start Offset: 0x0000
+		Data Start Offset: 0x0000
+		Access Method: General-purpose non-volatile data functions
+		Access Address: 0x0000
+		Status: Valid, Not Full
+		Change Token: 0x12345678
+		Header Format: OEM-specific
+		Supported Log Type Descriptors: 3
+		Descriptor 1: POST memory resize
+		Data Format 1: None
+		Descriptor 2: POST error
+		Data Format 2: POST results bitmap
+		Descriptor 3: Log area reset/cleared
+		Data Format 3: None
+
+Handle 0x0011, DMI type 32, 20 bytes
+System Boot Information
+		Status: No errors detected
+
+	`
+	sample4 = `
+# dmidecode 3.1
+Getting SMBIOS data from sysfs.
+SMBIOS 2.6 present.
+
+Handle 0x0000, DMI type 0, 24 bytes
+BIOS Information
+		Vendor: LENOVO
+		Version: 29CN40WW(V2.17)
+		Release Date: 04/13/2011
+		ROM Size: 2048 kB
+		Characteristics:
+				PCI is supported
+				BIOS is upgradeable
+				BIOS shadowing is allowed
+				Boot from CD is supported
+				Selectable boot is supported
+				EDD is supported
+				Japanese floppy for NEC 9800 1.2 MB is supported (int 13h)
+				Japanese floppy for Toshiba 1.2 MB is supported (int 13h)
+				5.25"/360 kB floppy services are supported (int 13h)
+				5.25"/1.2 MB floppy services are supported (int 13h)
+				3.5"/720 kB floppy services are supported (int 13h)
+				3.5"/2.88 MB floppy services are supported (int 13h)
+				8042 keyboard services are supported (int 9h)
+				CGA/mono video services are supported (int 10h)
+				ACPI is supported
+				USB legacy is supported
+				BIOS boot specification is supported
+				Targeted content distribution is supported
+		BIOS Revision: 1.40
+
+Handle 0x002C, DMI type 4, 42 bytes
+Processor Information
+		Socket Designation: CPU
+		Type: Central Processor
+		Family: Core 2 Duo
+		Manufacturer: Intel(R) Corporation
+		ID: 55 06 02 00 FF FB EB BF
+		Signature: Type 0, Family 6, Model 37, Stepping 5
+		Flags:
+				FPU (Floating-point unit on-chip)
+				VME (Virtual mode extension)
+				DE (Debugging extension)
+				PSE (Page size extension)
+				TSC (Time stamp counter)
+				MSR (Model specific registers)
+				PAE (Physical address extension)
+				MCE (Machine check exception)
+				CX8 (CMPXCHG8 instruction supported)
+				APIC (On-chip APIC hardware supported)
+				SEP (Fast system call)
+				MTRR (Memory type range registers)
+				PGE (Page global enable)
+				MCA (Machine check architecture)
+				CMOV (Conditional move instruction supported)
+				PAT (Page attribute table)
+				PSE-36 (36-bit page size extension)
+				CLFSH (CLFLUSH instruction supported)
+				DS (Debug store)
+				ACPI (ACPI supported)
+				MMX (MMX technology supported)
+				FXSR (FXSAVE and FXSTOR instructions supported)
+				SSE (Streaming SIMD extensions)
+				SSE2 (Streaming SIMD extensions 2)
+				SS (Self-snoop)
+				HTT (Multi-threading)
+				TM (Thermal monitor supported)
+				PBE (Pending break enabled)
+		Version: Intel(R) Core(TM) i3 CPU       M 370  @ 2.40GHz
+		Voltage: 0.0 V
+		External Clock: 1066 MHz
+		Max Speed: 2400 MHz
+		Current Speed: 2399 MHz
+		Status: Populated, Enabled
+		Upgrade: ZIF Socket
+		L1 Cache Handle: 0x0030
+		L2 Cache Handle: 0x002F
+		L3 Cache Handle: 0x002D
+		Serial Number: Not Specified
+		Asset Tag: FFFF
+		Part Number: Not Specified
+		Core Count: 2
+		Core Enabled: 2
+		Thread Count: 4
+		Characteristics:
+				64-bit capable
+	
+
+
+	`
+)
+
+func TestParseSectionSimple(t *testing.T) {
+	dmi, err := ParseDMI(sample1)
+	if ok := assert.Equal(t, err, nil); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 8, len(dmi.Sections[0].Properties)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "System Information", dmi.Sections[0].Title); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "2677240001087", dmi.Sections[0].Properties["Serial Number"].Val); !ok {
+		t.Fatal()
+	}
+
+}
+func TestParseSectionWithListProperty(t *testing.T) {
+	dmi, err := ParseDMI(sample2)
+	if ok := assert.Equal(t, err, nil); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 1, len(dmi.Sections)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 6, len(dmi.Sections[0].Properties)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "BIOS Information", dmi.Sections[0].Title); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "1.40", dmi.Sections[0].Properties["BIOS Revision"].Val); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 18, len(dmi.Sections[0].Properties["Characteristics"].Items)); !ok {
+
+		t.Fatal()
+	}
+
+}
+
+func TestParseMultipleSectionsSimple(t *testing.T) {
+	dmi, err := ParseDMI(sample3)
+	if ok := assert.Equal(t, err, nil); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, len(dmi.Sections), 4); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "System Information", dmi.Sections[0].Title); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 8, len(dmi.Sections[0].Properties)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "System Event Log", dmi.Sections[2].Title); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 15, len(dmi.Sections[2].Properties)); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "0 bytes", dmi.Sections[2].Properties["Area Length"].Val); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, DMITypeSystemBoot, dmi.Sections[3].Type); !ok {
+		t.Fatal()
+	}
+}
+func TestParseMultipleSectionsWithListProperties(t *testing.T) {
+	dmi, err := ParseDMI(sample4)
+	if ok := assert.Equal(t, err, nil); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 2, len(dmi.Sections)); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "BIOS Information", dmi.Sections[0].Title); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, len(dmi.Sections[0].Properties), 6); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, 18, len(dmi.Sections[0].Properties["Characteristics"].Items)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "PCI is supported", dmi.Sections[0].Properties["Characteristics"].Items[0]); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "LENOVO", dmi.Sections[0].Properties["Vendor"].Val); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "Processor Information", dmi.Sections[1].Title); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, len(dmi.Sections[1].Properties), 24); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, "2", dmi.Sections[1].Properties["Core Count"].Val); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, 28, len(dmi.Sections[1].Properties["Flags"].Items)); !ok {
+		t.Fatal()
+	}
+	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi.Sections[1].Properties["Flags"].Items[0]); !ok {
+		t.Fatal()
+	}
+}

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -406,3 +406,10 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 		}	
 	}
 }
+
+func BenchmarkParseMultipleSectionsWithLists(b *testing.B) {
+	// run the Fib function b.N times
+	for n := 0; n < b.N; n++ {
+		ParseDMI(sample4)
+	}
+}

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -264,13 +264,13 @@ var processorTests = map[string]string {
 
 func TestParseSectionSimple(t *testing.T) {
 	dmi, err := ParseDMI(sample1)
-	if ok:= assert.Equal(t, nil, err); !ok {
+	if ok:= assert.NoError(t, err); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 1, len(dmi)); !ok {
+	if ok := assert.Len(t, dmi, 1); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi["System Information"].Properties)); !ok {
+	if ok := assert.Len(t, dmi["System Information"].Properties, 8); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, "System Information", dmi["System Information"].Title); !ok {
@@ -286,20 +286,20 @@ func TestParseSectionSimple(t *testing.T) {
 }
 func TestParseSectionWithListProperty(t *testing.T) {
 	dmi, err := ParseDMI(sample2)
-	if ok:= assert.Equal(t, nil, err); !ok {
+	if ok:= assert.NoError(t, err); !ok {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, 1, len(dmi)); !ok {
+	if ok := assert.Len(t, dmi, 1); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 6, len(dmi["BIOS Information"].Properties)); !ok {
+	if ok := assert.Len(t, dmi["BIOS Information"].Properties, 6); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, "BIOS Information", dmi["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Len(t, dmi["BIOS Information"].Properties["Characteristics"].Items, 18); !ok {
 
 		t.Fatal()
 	}
@@ -314,23 +314,23 @@ func TestParseSectionWithListProperty(t *testing.T) {
 
 func TestParseMultipleSectionsSimple(t *testing.T) {
 	dmi, err := ParseDMI(sample3)
-	if ok:= assert.Equal(t, nil, err); !ok {
+	if ok:= assert.NoError(t, err); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, len(dmi), 4); !ok {
+	if ok := assert.Len(t, dmi, 4); !ok {
 		t.Fatal()
 	}
 
 	if ok := assert.Equal(t, "System Information", dmi["System Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 8, len(dmi["System Information"].Properties)); !ok {
+	if ok := assert.Len(t, dmi["System Information"].Properties, 8); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, "System Event Log", dmi["System Event Log"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 15, len(dmi["System Event Log"].Properties)); !ok {
+	if ok := assert.Len(t, dmi["System Event Log"].Properties, 15); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, DMITypeSystemBoot, dmi["System Boot Information"].Type); !ok {
@@ -361,20 +361,20 @@ func TestParseMultipleSectionsSimple(t *testing.T) {
 }
 func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 	dmi, err := ParseDMI(sample4)
-	if ok:= assert.Equal(t, nil, err); !ok {
+	if ok:= assert.NoError(t, err); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 2, len(dmi)); !ok {
+	if ok := assert.Len(t, dmi, 2); !ok {
 		t.Fatal()
 	}
 
 	if ok := assert.Equal(t, "BIOS Information", dmi["BIOS Information"].Title); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, len(dmi["BIOS Information"].Properties), 6); !ok {
+	if ok := assert.Len(t, dmi["BIOS Information"].Properties, 6); !ok {
 		t.Fatal()
 	}
-	if ok := assert.Equal(t, 18, len(dmi["BIOS Information"].Properties["Characteristics"].Items)); !ok {
+	if ok := assert.Len(t, dmi["BIOS Information"].Properties["Characteristics"].Items, 18); !ok {
 		t.Fatal()
 	}
 
@@ -382,12 +382,12 @@ func TestParseMultipleSectionsWithListProperties(t *testing.T) {
 		t.Fatal()
 	}
 
-	if ok := assert.Equal(t, len(dmi["Processor Information"].Properties), 24); !ok {
+	if ok := assert.Len(t, dmi["Processor Information"].Properties, 24); !ok {
 		t.Fatal()
 	}
 
 
-	if ok := assert.Equal(t, 28, len(dmi["Processor Information"].Properties["Flags"].Items)); !ok {
+	if ok := assert.Len(t, dmi["Processor Information"].Properties["Flags"].Items, 28); !ok {
 		t.Fatal()
 	}
 	if ok := assert.Equal(t, "FPU (Floating-point unit on-chip)", dmi["Processor Information"].Properties["Flags"].Items[0]); !ok {

--- a/apps/core0/builtin/dmi_test.go
+++ b/apps/core0/builtin/dmi_test.go
@@ -21,7 +21,6 @@ System Information
 		Wake-up Type: Power Switch
 		SKU Number: Calpella_CRB
 		Family: Intel_Mobile
-
 	`
 	sample2 = `
 Getting SMBIOS data from sysfs.
@@ -53,7 +52,6 @@ BIOS Information
 				BIOS boot specification is supported
 				Targeted content distribution is supported
 		BIOS Revision: 1.40
-
 	`
 	sample3 = `
 # dmidecode 3.1
@@ -99,8 +97,6 @@ System Event Log
 Handle 0x0011, DMI type 32, 20 bytes
 System Boot Information
 		Status: No errors detected
-
-
 	`
 	sample4 = `
 # dmidecode 3.1
@@ -189,7 +185,6 @@ Processor Information
 		Thread Count: 4
 		Characteristics:
 				64-bit capable
-
 	`
 )
 var	biosInfoTests = map[string]string{


### PR DESCRIPTION
Fixes #548 

Add command `core.dmidecode` as a primitive to core0 with allowed `typenums` as argument to specify what kind of types to be returned from dmidecode by number and `typekeywords` to support getting dmi sections by keywords

Examples:
```
In [147]: cl.raw("core.dmidecode", {'typenums': [1,16]}).get()
Out[147]: 
STATE: 0 SUCCESS
STDOUT:

STDERR:

DATA:
{"Physical Memory Array":{"handleline":"Handle 0x1000, DMI type 16, 23 bytes","title":"Physical Memory Array","typestr":"PhysicalMemoryArray","typenum":16,"properties":{"Error Correction Type":{"value":"Multi-bit ECC"},"Error Information Handle":{"value":"Not Provided"},"Location":{"value":"Other"},"Maximum Capacity":{"value":"5 GB"},"Number Of Devices":{"value":"1"},"Use":{"value":"System Memory"}}},"System Information":{"handleline":"Handle 0x0100, DMI type 1, 27 bytes","title":"System Information","typestr":"System","typenum":1,"properties":{"Family":{"value":"Not Specified"},"Manufacturer":{"value":"QEMU"},"Product Name":{"value":"Standard PC (i440FX + PIIX, 1996)"},"SKU Number":{"value":"Not Specified"},"Serial Number":{"value":"Not Specified"},"UUID":{"value":"Not Settable"},"Version":{"value":"pc-i440fx-xenial"},"Wake-up Type":{"value":"Power Switch"}}}}


In [149]: cl.raw("core.dmidecode", {'typekeywords': ["memory"]}).get()
Out[149]: 
STATE: 0 SUCCESS
STDOUT:

STDERR:

DATA:
{"Memory Device":{"handleline":"Handle 0x1100, DMI type 17, 40 bytes","title":"Memory Device","typestr":"MemoryDevice","typenum":17,"properties":{"Array Handle":{"value":"0x1000"},"Asset Tag":{"value":"Not Specified"},"Bank Locator":{"value":"Not Specified"},"Configured Clock Speed":{"value":"Unknown"},"Configured Voltage":{"value":"Unknown"},"Data Width":{"value":"Unknown"},"Error Information Handle":{"value":"Not Provided"},"Form Factor":{"value":"DIMM"},"Locator":{"value":"DIMM 0"},"Manufacturer":{"value":"QEMU"},"Maximum Voltage":{"value":"Unknown"},"Minimum Voltage":{"value":"Unknown"},"Part Number":{"value":"Not Specified"},"Rank":{"value":"Unknown"},"Serial Number":{"value":"Not Specified"},"Set":{"value":"None"},"Size":{"value":"5120 MB"},"Speed":{"value":"Unknown"},"Total Width":{"value":"Unknown"},"Type":{"value":"RAM"},"Type Detail":{"value":"Other"}}},"Physical Memory Array":{"handleline":"Handle 0x1000, DMI type 16, 23 bytes","title":"Physical Memory Array","typestr":"PhysicalMemoryArray","typenum":16,"properties":{"Error Correction Type":{"value":"Multi-bit ECC"},"Error Information Handle":{"value":"Not Provided"},"Location":{"value":"Other"},"Maximum Capacity":{"value":"5 GB"},"Number Of Devices":{"value":"1"},"Use":{"value":"System Memory"}}}}


```