### PR TITLE
Use new virtio-scsi for higher compatibility

### DIFF
--- a/apps/core0/subsys/kvm/manager.go
+++ b/apps/core0/subsys/kvm/manager.go
@@ -662,7 +662,7 @@ func (m *kvmManager) mkZDBDisk(media Media) (arg QemuArg, err error) {
 		args = append(args, fmt.Sprintf("socket=%s", u.Path))
 	}
 
-	arg.Value = fmt.Sprintf("driver=zdb,%s,if=virtio", strings.Join(args, ","))
+	arg.Value = fmt.Sprintf("driver=zdb,%s,if=virtio-scsi", strings.Join(args, ","))
 	return
 }
 


### PR DESCRIPTION
See: https://www.ovirt.org/develop/release-management/features/storage/virtio-scsi/

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>