### PR TITLE
portforward using dnat rules

### DIFF
--- a/apps/core0/bootstrap/nft.go
+++ b/apps/core0/bootstrap/nft.go
@@ -50,11 +50,7 @@ var (
 					Type:     nft.TypeFilter,
 					Hook:     "forward",
 					Priority: 0,
-					Policy:   "drop",
-					Rules: []nft.Rule{
-						{Body: "ct state {established, related} accept"},
-						{Body: "meta mark 1 accept"}, // all bridges we create with nat support has this mart set
-					},
+					Policy:   "accept",
 				},
 				"output": nft.Chain{
 					Type:     nft.TypeFilter,

--- a/apps/core0/bootstrap/nft.go
+++ b/apps/core0/bootstrap/nft.go
@@ -28,6 +28,12 @@ var (
 		"filter": nft.Table{
 			Family: nft.FamilyINET,
 			Chains: nft.Chains{
+				"pre": nft.Chain{
+					Type:     nft.TypeFilter,
+					Hook:     "prerouting",
+					Priority: 0,
+					Policy:   "accept",
+				},
 				"input": nft.Chain{
 					Type:     nft.TypeFilter,
 					Hook:     "input",
@@ -44,7 +50,11 @@ var (
 					Type:     nft.TypeFilter,
 					Hook:     "forward",
 					Priority: 0,
-					Policy:   "accept",
+					Policy:   "drop",
+					Rules: []nft.Rule{
+						{Body: "ct state {established, related} accept"},
+						{Body: "meta mark 1 accept"}, // all bridges we create with nat support has this mart set
+					},
 				},
 				"output": nft.Chain{
 					Type:     nft.TypeFilter,

--- a/apps/core0/builtin/bridge.go
+++ b/apps/core0/builtin/bridge.go
@@ -480,6 +480,12 @@ func (b *bridgeMgr) nft(br string) error {
 						{Body: fmt.Sprintf("iif %s udp dport {53,67,68} accept", name)},
 					},
 				},
+				"forward": nft.Chain{
+					Rules: []nft.Rule{
+						{Body: fmt.Sprintf("iif %s oif %s meta mark set 2", name, name)},
+						{Body: fmt.Sprintf("oif %s meta mark 1 drop", name)},
+					},
+				},
 			},
 		},
 	}

--- a/apps/core0/builtin/bridge.go
+++ b/apps/core0/builtin/bridge.go
@@ -480,12 +480,6 @@ func (b *bridgeMgr) nft(br string) error {
 						{Body: fmt.Sprintf("iif %s udp dport {53,67,68} accept", name)},
 					},
 				},
-				"forward": nft.Chain{
-					Rules: []nft.Rule{
-						{Body: fmt.Sprintf("iif %s oif %s meta mark set 2", name, name)},
-						{Body: fmt.Sprintf("oif %s meta mark 1 drop", name)},
-					},
-				},
 			},
 		},
 	}

--- a/apps/core0/builtin/bridge.go
+++ b/apps/core0/builtin/bridge.go
@@ -509,7 +509,7 @@ func (b *bridgeMgr) unNFT(idx int) error {
 		for cname, chain := range table.Chains {
 			for _, rule := range chain.Rules {
 				if ok := pat.MatchString(rule.Body); ok {
-					if err := nft.Drop(tname, cname, rule.Handle); err != nil {
+					if err := nft.Drop(table.Family, tname, cname, rule.Handle); err != nil {
 						log.Errorf("nft delete rule: %s", err)
 						errored = true
 					}

--- a/apps/core0/conf/redis.toml
+++ b/apps/core0/conf/redis.toml
@@ -31,4 +31,4 @@ condition = "development"
 [startup.redis-port.args]
 port=6379
 #only set interface to zt0 if zerotier is set
-"zerotier: interface" = "zt0"
+"zerotier| interface" = "zt0"

--- a/apps/core0/conf/redis.toml
+++ b/apps/core0/conf/redis.toml
@@ -23,19 +23,12 @@ args = [
     "--listen", "0.0.0.0:6379"
 ]
 
-[startup."redis-proxy-pub"]
+[startup.redis-port]
 name = "nft.open_port"
-#open on all interfaces if development is set and zerotier is not set
-condition = "and(development, not(zerotier))"
+#open port only if `development`
+condition = "development"
 
-[startup."redis-proxy-pub".args]
+[startup.redis-port.args]
 port=6379
-
-[startup."redis-proxy-zt"]
-name = "nft.open_port"
-# only open on the zt interface if both development and zerotier are set
-condition = "and(development, zerotier)"
-
-[startup."redis-proxy-zt".args]
-port=6379
-interface="zt0"
+#only set interface to zt0 if zerotier is set
+"zerotier: interface" = "zt0"

--- a/apps/core0/helper/socat/socat.go
+++ b/apps/core0/helper/socat/socat.go
@@ -10,6 +10,10 @@ import (
 	"github.com/op/go-logging"
 )
 
+const (
+	addressAll = "0.0.0.0"
+)
+
 var (
 	log  = logging.MustGetLogger("socat")
 	lock sync.Mutex
@@ -25,6 +29,32 @@ type rule struct {
 
 func (r rule) Rule(host int) string {
 	return fmt.Sprintf("tcp dport %d dnat to %s:%d", host, r.ip, r.port)
+}
+
+type source struct {
+	ip   string
+	port int
+}
+
+func getSource(src string) (source, error) {
+	parts := strings.SplitN(src, ":", 2)
+	var r = source{
+		ip: addressAll,
+	}
+
+	if _, err := fmt.Sscanf(parts[len(parts)-1], "%d", &r.port); err != nil {
+		return r, err
+	}
+
+	if r.port <= 0 || r.port >= 65536 {
+		return r, fmt.Errorf("invalid port number")
+	}
+
+	if len(parts) == 2 {
+		r.ip = parts[0]
+	}
+
+	return r, nil
 }
 
 //SetPortForward create a single port forward from host, to dest in this namespace

--- a/apps/core0/helper/socat/socat.go
+++ b/apps/core0/helper/socat/socat.go
@@ -4,79 +4,145 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"syscall"
 
-	"encoding/json"
+	"github.com/zero-os/0-core/base/nft"
 
 	"github.com/op/go-logging"
-	"github.com/zero-os/0-core/base/builtin"
-	"github.com/zero-os/0-core/base/pm"
 )
 
 var (
 	log  = logging.MustGetLogger("socat")
 	lock sync.Mutex
+
+	rules = map[int]rule{}
 )
 
-func SetPortForward(id string, ip string, host int, dest int) error {
+type rule struct {
+	ns   string
+	port int
+	ip   string
+}
+
+func (r rule) Rule(host int) string {
+	return fmt.Sprintf("tcp dport %d dnat to %s:%d", host, r.ip, r.port)
+}
+
+//SetPortForward create a single port forward from host, to dest in this namespace
+//The namespace is used to group port forward rules so they all can get terminated
+//with one call later.
+func SetPortForward(namespace string, ip string, host int, dest int) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	var ports []*builtin.Port
-	job, err := pm.Run(&pm.Command{
-		Command: "info.port",
-	})
-	result := job.Wait()
-	if err := json.Unmarshal([]byte(result.Data), &ports); err != nil {
+	//NOTE: this will only check if the port is used for port forwarding
+	//if a port on the host is using this port it will get masked out
+	if _, exists := rules[host]; exists {
+		return fmt.Errorf("port already in use")
+	}
+
+	r := rule{
+		ns:   forwardId(namespace, host, dest),
+		port: dest,
+		ip:   ip,
+	}
+
+	set := nft.Nft{
+		"nat": nft.Table{
+			Family: nft.FamilyIP,
+			Chains: nft.Chains{
+				"pre": nft.Chain{
+					Rules: []nft.Rule{
+						{Body: r.Rule(host)},
+					},
+				},
+			},
+		},
+	}
+
+	if err := nft.Apply(set); err != nil {
 		return err
 	}
 
-	for _, port := range ports {
-		if port.Network != "unix" && int(port.Port) == host {
-			return fmt.Errorf("Can't forward from port %d, host is already listening on it", host)
-		}
+	rules[host] = r
+	return nil
+}
+
+func forwardId(namespace string, host int, dest int) string {
+	return fmt.Sprintf("socat-%v-%v-%v", namespace, host, dest)
+}
+
+//RemovePortForward removes a single port forward
+func RemovePortForward(namespace string, host int, dest int) error {
+	lock.Lock()
+	defer lock.Unlock()
+	rule, ok := rules[host]
+	if !ok {
+		return fmt.Errorf("no port forwrard from host port: %d", host)
 	}
 
-	//nft add rule nat prerouting iif eth0 tcp dport { 80, 443 } dnat 192.168.1.120
-	cmd := &pm.Command{
-		ID:      forwardId(id, host, dest),
-		Command: pm.CommandSystem,
-		Flags: pm.JobFlags{
-			NoOutput: true,
-		},
-		Arguments: pm.MustArguments(
-			pm.SystemCommandArguments{
-				Name: "socat",
-				Args: []string{
-					fmt.Sprintf("tcp-listen:%d,reuseaddr,fork", host),
-					fmt.Sprintf("tcp-connect:%s:%d", ip, dest),
+	if rule.ns != forwardId(namespace, host, dest) {
+		return fmt.Errorf("permission denied")
+	}
+
+	set := nft.Nft{
+		"nat": nft.Table{
+			Family: nft.FamilyIP,
+			Chains: nft.Chains{
+				"pre": nft.Chain{
+					Rules: []nft.Rule{
+						{Body: rule.Rule(host)},
+					},
 				},
 			},
-		),
-	}
-	onExit := &pm.ExitHook{
-		Action: func(s bool) {
-			log.Infof("Port forward %d:%d with id %s exited", host, dest, id)
 		},
 	}
 
-	_, err = pm.Run(cmd, onExit)
-	return err
+	return nft.Apply(set)
 }
 
-func forwardId(id string, host int, dest int) string {
-	return fmt.Sprintf("socat-%v-%v-%v", id, host, dest)
-}
+//RemoveAll remove all port forwrards that were created in this namespace.
+func RemoveAll(namespace string) error {
+	lock.Lock()
+	defer lock.Unlock()
 
-func RemovePortForward(id string, host int, dest int) error {
-	return pm.Kill(forwardId(id, host, dest))
-}
+	var todelete []nft.Rule
+	var hostPorts []int
 
-func RemoveAll(id string) {
-	for key, job := range pm.Jobs() {
-		if strings.HasPrefix(key, fmt.Sprintf("socat-%s", id)) {
-			log.Debugf("stopping socat process: %s", key)
-			job.Signal(syscall.SIGTERM)
+	for host, r := range rules {
+		if !strings.HasPrefix(r.ns, fmt.Sprintf("socat-%s", namespace)) {
+			continue
 		}
+
+		todelete = append(todelete, nft.Rule{
+			Body: r.Rule(host),
+		})
+
+		hostPorts = append(hostPorts, host)
 	}
+
+	if len(todelete) == 0 {
+		return nil
+	}
+
+	set := nft.Nft{
+		"nat": nft.Table{
+			Family: nft.FamilyIP,
+			Chains: nft.Chains{
+				"pre": nft.Chain{
+					Rules: todelete,
+				},
+			},
+		},
+	}
+
+	if err := nft.DropRules(set); err != nil {
+		log.Errorf("failed to delete ruleset: %s", err)
+		return err
+	}
+
+	for _, host := range hostPorts {
+		delete(rules, host)
+	}
+
+	return nil
 }

--- a/apps/core0/helper/socat/socat_test.go
+++ b/apps/core0/helper/socat/socat_test.go
@@ -1,0 +1,52 @@
+package socat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSource(t *testing.T) {
+	src, err := getSource("2200")
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, source{"0.0.0.0", 2200}, src); !ok {
+		t.Error()
+	}
+
+	src, err = getSource("10.20.30.40:2200")
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, source{"10.20.30.40", 2200}, src); !ok {
+		t.Error()
+	}
+
+	src, err = getSource("eth0:2200")
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, source{"eth0", 2200}, src); !ok {
+		t.Error()
+	}
+
+	src, err = getSource("eth0:0")
+	if ok := assert.Error(t, err); !ok {
+		t.Fatal()
+	}
+
+	src, err = getSource("eth0")
+	if ok := assert.Error(t, err); !ok {
+		t.Fatal()
+	}
+
+	src, err = getSource("")
+	if ok := assert.Error(t, err); !ok {
+		t.Fatal()
+	}
+
+}

--- a/apps/core0/subsys/containers/manager.go
+++ b/apps/core0/subsys/containers/manager.go
@@ -495,12 +495,14 @@ func (m *containerManager) createContainer(args ContainerCreateArguments) (*cont
 func (m *containerManager) createSync(cmd *pm.Command) (interface{}, error) {
 	var args ContainerCreateArguments
 	if err := json.Unmarshal(*cmd.Arguments, &args); err != nil {
+		log.Errorf("invalid container params: %s", err)
 		return nil, err
 	}
 
 	args.Tags = cmd.Tags
 	container, err := m.createContainer(args)
 	if err != nil {
+		log.Errorf("failed to start container: %s", err)
 		return nil, err
 	}
 

--- a/apps/core0/subsys/containers/manager.go
+++ b/apps/core0/subsys/containers/manager.go
@@ -88,7 +88,7 @@ type ContainerCreateArguments struct {
 	HostNetwork bool              `json:"host_network"` //share host networking stack
 	Identity    string            `json:"identity"`     //zerotier identity
 	Nics        []*Nic            `json:"nics"`         //network setup (only respected if HostNetwork is false)
-	Port        map[int]int       `json:"port"`         //port forwards (only if default networking is enabled)
+	Port        map[string]int    `json:"port"`         //port forwards (only if default networking is enabled)
 	Privileged  bool              `json:"privileged"`   //Apply cgroups and capabilities limitations on the container
 	Hostname    string            `json:"hostname"`     //hostname
 	Storage     string            `json:"storage"`      //ardb storage needed for g8ufs mounts.
@@ -105,7 +105,7 @@ type ContainerDispatchArguments struct {
 type containerPortForward struct {
 	Container     uint16 `json:"container"`
 	ContainerPort int    `json:"container_port"`
-	HostPort      int    `json:"host_port"`
+	HostPort      string `json:"host_port"`
 }
 
 func (c *ContainerCreateArguments) Validate() error {
@@ -135,8 +135,8 @@ func (c *ContainerCreateArguments) Validate() error {
 	}
 
 	for host, guest := range c.Port {
-		if host < 0 || host > 65535 {
-			return fmt.Errorf("invalid host port '%d'", host)
+		if !socat.ValidHost(host) {
+			return fmt.Errorf("invalid host port '%s'", host)
 		}
 		if guest < 0 || guest > 65535 {
 			return fmt.Errorf("invalid guest port '%d'", guest)

--- a/apps/core0/subsys/containers/network.go
+++ b/apps/core0/subsys/containers/network.go
@@ -411,7 +411,7 @@ func (c *container) forwardId() string {
 	return fmt.Sprintf("container-%d", c.id)
 }
 
-func (c *container) setPortForward(host int, dest int) error {
+func (c *container) setPortForward(host string, dest int) error {
 	ip := c.getDefaultIP().String()
 	return socat.SetPortForward(c.forwardId(), ip, host, dest)
 }

--- a/apps/core0/subsys/kvm/manager.go
+++ b/apps/core0/subsys/kvm/manager.go
@@ -184,8 +184,8 @@ type Nic struct {
 	HWAddress string `json:"hwaddr"`
 }
 type NicParams struct {
-	Nics []Nic       `json:"nics"`
-	Port map[int]int `json:"port"`
+	Nics []Nic          `json:"nics"`
+	Port map[string]int `json:"port"`
 }
 
 type Mount struct {
@@ -217,7 +217,7 @@ type FListBootConfig struct {
 type kvmPortForward struct {
 	UUID          string `json:"uuid"`
 	ContainerPort int    `json:"container_port"`
-	HostPort      int    `json:"host_port"`
+	HostPort      string `json:"host_port"`
 }
 
 func (c *CreateParams) Valid() error {
@@ -820,13 +820,13 @@ func (m *kvmManager) mkDomain(seq uint16, params *CreateParams) (*Domain, error)
 	return &domain, nil
 }
 
-func (m *kvmManager) setPortForward(uuid string, seq uint16, host int, container int) error {
+func (m *kvmManager) setPortForward(uuid string, seq uint16, host string, container int) error {
 	ip := m.ipAddr(seq)
 	id := m.forwardId(uuid)
 	return socat.SetPortForward(id, ip, host, container)
 }
 
-func (m *kvmManager) setPortForwards(uuid string, seq uint16, port map[int]int) error {
+func (m *kvmManager) setPortForwards(uuid string, seq uint16, port map[string]int) error {
 	for host, container := range port {
 		if err := m.setPortForward(uuid, seq, host, container); err != nil {
 			return err
@@ -1226,7 +1226,7 @@ func (m *kvmManager) addNic(cmd *pm.Command) (interface{}, error) {
 			return nil, fmt.Errorf("in setup networking couldn't get domaininfo for domain %s", params.UUID)
 		}
 
-		inf, err = m.prepareDefaultNetwork(params.UUID, domainInfo.Sequence, map[int]int{})
+		inf, err = m.prepareDefaultNetwork(params.UUID, domainInfo.Sequence, map[string]int{})
 	case "bridge":
 		if nic.ID == DefaultBridgeName {
 			err = fmt.Errorf("the default bridge for the vm should not be added manually")

--- a/apps/core0/subsys/kvm/network.go
+++ b/apps/core0/subsys/kvm/network.go
@@ -214,7 +214,7 @@ func (m *kvmManager) prepareVXLanNetwork(nic *Nic) (*InterfaceDevice, error) {
 	return &inf, nil
 }
 
-func (m *kvmManager) prepareDefaultNetwork(uuid string, seq uint16, port map[int]int) (*InterfaceDevice, error) {
+func (m *kvmManager) prepareDefaultNetwork(uuid string, seq uint16, port map[string]int) (*InterfaceDevice, error) {
 	_, err := netlink.LinkByName(DefaultBridgeName)
 	if err != nil {
 		return nil, fmt.Errorf("bridge '%s' not found", DefaultBridgeName)

--- a/base/nft/nft_test.go
+++ b/base/nft/nft_test.go
@@ -37,3 +37,91 @@ func TestMarshal(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestFindRules(t *testing.T) {
+	config := `table ip nat {
+	chain pre {
+		type nat hook prerouting priority 0; policy accept;
+		iif "core0" mark set 0x00000001 # handle 3
+		iif "kvm0" mark set 0x00000001 # handle 6
+		tcp dport 6600 dnat to 172.18.0.2:6600 # handle 9
+		tcp dport 2200 dnat to 172.19.0.2:22 # handle 10
+	}
+
+	chain post {
+		type nat hook postrouting priority 0; policy accept;
+		ip saddr 172.18.0.0/16 masquerade # handle 5
+		ip saddr 172.19.0.0/16 masquerade # handle 7
+	}
+}
+table inet filter {
+	chain input {
+		type filter hook input priority 0; policy drop;
+		ct state { related, established} accept # handle 4
+		iifname "lo" accept # handle 5
+		iifname "vxbackend" accept # handle 6
+		ip protocol 1 accept # handle 7
+		iif "core0" udp dport { 68, 53, 67} accept # handle 8
+		tcp dport 6600 accept # handle 11
+		tcp dport 6379 accept # handle 12
+		tcp dport 22 accept # handle 13
+		iif "kvm0" udp dport { 67, 53, 68} accept # handle 16
+		tcp dport 5900 accept # handle 17
+	}
+
+	chain forward {
+		type filter hook forward priority 0; policy accept;
+		iif "core0" oif "core0" mark set 0x00000002 # handle 9
+		oif "core0" mark 0x00000001 drop # handle 10
+		iif "kvm0" oif "kvm0" mark set 0x00000002 # handle 14
+		oif "kvm0" mark 0x00000001 drop # handle 15
+	}
+
+	chain output {
+		type filter hook output priority 0; policy accept;
+	}
+}
+	`
+
+	ruleset, err := Parse(config)
+
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	sub := Nft{
+		"nat": Table{
+			Family: FamilyIP,
+			Chains: Chains{
+				"pre": Chain{
+					Rules: []Rule{
+						{Body: "tcp dport 2200 dnat to 172.19.0.2:22"},
+					},
+				},
+			},
+		},
+		"filter": Table{
+			Family: FamilyINET,
+			Chains: Chains{
+				"input": Chain{
+					Rules: []Rule{
+						{Body: "tcp dport 5900 accept"},
+					},
+				},
+			},
+		},
+	}
+
+	sub, err = findRules(ruleset, sub)
+	if ok := assert.NoError(t, err); !ok {
+		t.Fatal()
+	}
+
+	if ok := assert.Equal(t, 10, sub["nat"].Chains["pre"].Rules[0].Handle); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, 17, sub["filter"].Chains["input"].Rules[0].Handle); !ok {
+		t.Error()
+	}
+}

--- a/base/pm/pm.go
+++ b/base/pm/pm.go
@@ -197,8 +197,9 @@ func Start() {
 }
 
 func processArgs(args map[string]interface{}, values map[string]interface{}) {
-	for key, value := range args {
-		parts := strings.SplitN(key, ":", 2)
+	for _, key := range utils.GetKeys(args) {
+		value := args[key]
+		parts := strings.SplitN(key, "|", 2)
 		if len(parts) == 2 {
 			//this key is in form of "cond:key" = value
 			exp, err := settings.GetExpression(strings.TrimSpace(parts[0]))
@@ -231,14 +232,15 @@ func processArgs(args map[string]interface{}, values map[string]interface{}) {
 			for _, subvalue := range value {
 				if subvalue, ok := subvalue.(string); ok {
 					newstrlist = append(newstrlist, utils.Format(subvalue, values))
-				} else {
-					newstrlist = append(newstrlist, subvalue)
+					continue
 				}
+				newstrlist = append(newstrlist, subvalue)
 			}
 
 			args[key] = newstrlist
 		case map[string]interface{}:
 			processArgs(value, values)
+			args[key] = value
 		}
 	}
 }

--- a/base/pm/pm.go
+++ b/base/pm/pm.go
@@ -198,18 +198,49 @@ func Start() {
 
 func processArgs(args map[string]interface{}, values map[string]interface{}) {
 	for key, value := range args {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) == 2 {
+			//this key is in form of "cond:key" = value
+			exp, err := settings.GetExpression(strings.TrimSpace(parts[0]))
+			if err != nil {
+				log.Errorf("failed to process startup argument '%s': %s", key, err)
+				continue
+			}
+
+			delete(args, key)
+
+			if !exp.Examine(values) {
+				//the rule did not match, hide the argument
+				continue
+			}
+
+			key = strings.TrimSpace(parts[1])
+		}
+
 		switch value := value.(type) {
 		case string:
 			args[key] = utils.Format(value, values)
 		case []string:
-			newstrlist := make([]string, len(value))
+			var newstrlist []string
 			for _, strvalue := range value {
 				newstrlist = append(newstrlist, utils.Format(strvalue, values))
 			}
 			args[key] = newstrlist
+		case []interface{}:
+			var newstrlist []interface{}
+			for _, subvalue := range value {
+				if subvalue, ok := subvalue.(string); ok {
+					newstrlist = append(newstrlist, utils.Format(subvalue, values))
+				} else {
+					newstrlist = append(newstrlist, subvalue)
+				}
+			}
+
+			args[key] = newstrlist
+		case map[string]interface{}:
+			processArgs(value, values)
 		}
 	}
-
 }
 
 /*

--- a/base/pm/pm_test.go
+++ b/base/pm/pm_test.go
@@ -1,0 +1,111 @@
+package pm
+
+import (
+	"testing"
+
+	"github.com/naoina/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessArguments(t *testing.T) {
+
+	values := map[string]interface{}{
+		"name": "Azmy",
+		"age":  36,
+	}
+
+	args := map[string]interface{}{
+		"intvalue": 100,
+		"strvalue": "hello {name}",
+		"deeplist": []string{"my", "age", "is", "{age}"},
+		"deepmap": map[string]interface{}{
+			"subkey": "my name is {name} and I am {age} years old",
+		},
+	}
+
+	processArgs(args, values)
+
+	if ok := assert.Equal(t, "hello Azmy", args["strvalue"]); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, []string{"my", "age", "is", "36"}, args["deeplist"]); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, map[string]interface{}{
+		"subkey": "my name is Azmy and I am 36 years old",
+	}, args["deepmap"]); !ok {
+		t.Error()
+	}
+}
+
+func TestProcessArgumentsFromToml(t *testing.T) {
+
+	source := `
+key = "my name is {name}"
+list = ["hello", "{name}"]
+
+[sub]
+sub = "my age is {age}"
+	`
+
+	var args map[string]interface{}
+
+	if err := toml.Unmarshal([]byte(source), &args); err != nil {
+		t.Fatal(err)
+	}
+
+	values := map[string]interface{}{
+		"name": "Azmy",
+		"age":  36,
+	}
+
+	processArgs(args, values)
+
+	if ok := assert.Equal(t, "my name is Azmy", args["key"]); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, []interface{}{"hello", "Azmy"}, args["list"]); !ok {
+		t.Error()
+	}
+
+	if ok := assert.Equal(t, map[string]interface{}{
+		"sub": "my age is 36",
+	}, args["sub"]); !ok {
+		t.Error()
+	}
+}
+
+func TestProcessArgumentsCondition(t *testing.T) {
+	values := map[string]interface{}{
+		"name": "Azmy",
+	}
+
+	args := map[string]interface{}{
+		"name: value": "{name}",
+		"age: value":  "{age}",
+	}
+
+	processArgs(args, values)
+
+	if ok := assert.Equal(t, "Azmy", args["value"]); !ok {
+		t.Error()
+	}
+
+	values = map[string]interface{}{
+		"age": "36",
+	}
+
+	args = map[string]interface{}{
+		"name: value": "{name}",
+		"age : value": "{age}",
+	}
+
+	processArgs(args, values)
+
+	if ok := assert.Equal(t, "36", args["value"]); !ok {
+		t.Error()
+	}
+}

--- a/client/py-client/zeroos/core0/client/client.py
+++ b/client/py-client/zeroos/core0/client/client.py
@@ -988,6 +988,7 @@ class ContainerManager:
         'nics': [_nic],
         'port': typchk.Or(
             typchk.Map(int, int),
+            typchk.Map(str, int),
             typchk.IsNone()
         ),
         'privileged': bool,
@@ -1016,8 +1017,6 @@ class ContainerManager:
     })
 
     DefaultNetworking = object()
-
-
 
     def __init__(self, client):
         self._client = client
@@ -2053,6 +2052,7 @@ class KvmManager:
         }],
         'port': typchk.Or(
             typchk.Map(int, int),
+            typchk.Map(str, int),
             typchk.IsNone()
         ),
         'mount': typchk.Or(
@@ -2077,6 +2077,7 @@ class KvmManager:
         }],
         'port': typchk.Or(
             typchk.Map(int, int),
+            typchk.Map(str, int),
             typchk.IsNone()
         ),
         'uuid': str

--- a/docs/config/startup.md
+++ b/docs/config/startup.md
@@ -52,6 +52,16 @@ Bash for example requires only `script` argument also accepts `stdin`
 > Startup `args` section also supports the `{variable}` name substitution. But it substitute the keys
 with values passed to the kernel cmdline.
 
+## Startup `args` conditions
+Sometimes you want to apply different arguments based on a condition. Similar to the condition parameter above which control the entire service startup, an argument
+can prefixed with a condition string. If the condition is not evaluated to true, the argument is dropped from the args block.
+
+```
+condition|argname = value
+```
+
+A real life example use of this option can be found [here](../../apps/core0/conf/redis.toml) where redis port opens on zt0 interface only if `zerotier` is set
+
 ## Condition Syntax
 ```
 expression := and(expression, expression, ...)

--- a/docs/interacting/commands/container.md
+++ b/docs/interacting/commands/container.md
@@ -68,7 +68,7 @@ Values:
 
   - **{hwaddr}**: (optional) MAC address
 
-  - **{config}**: Only relevant for bridge, VLAN and VXLAN types:  
+  - **{config}**: Only relevant for bridge, VLAN and VXLAN types:
     - `{dhcp}`: True/False. Runs the `Udhcpc` DHCP client on the container link, of course this will only work if the bridge is created with `dnsmasq` networking
     - `{CIDR}`: Assigns a static IP address to the link
     - `{gateway}`: gateway
@@ -76,7 +76,10 @@ Values:
 
 - **port**: Dict of `{host_port}: {container_port}` pairs
 
-  Example: `port=[8080: 80, 7000:7000]`
+  - Example: `port={'8080': 80, '7000':7000}`
+  - Example: `port={'192.168.1.1:8080': 80}` only accept connection from this ip
+  - Example: `port={'192.168.1.0/24:8080': 80}` only accept connection from this network
+  - Example: `port={'eth0:8080': 80}` only accept connection from this device
 
 - **{hostname}**: Specific hostname you want to give to the container
   - If none it will automatically be set to `core-x`, x being the ID of the container

--- a/docs/interacting/commands/kvm.md
+++ b/docs/interacting/commands/kvm.md
@@ -27,6 +27,12 @@ Arguments:
   'mount': [{'source': {source}, 'target': {target}, 'readonly': true|false}] //optional
 }
 ```
+**port**: Dict of `{host_port}: {container_port}` pairs
+
+  - Example: `port={'8080': 80, '7000':7000}`
+  - Example: `port={'192.168.1.1:8080': 80}` only accept connection from this ip
+  - Example: `port={'192.168.1.0/24:8080': 80}` only accept connection from this network
+  - Example: `port={'eth0:8080': 80}` only accept connection from this device
 
 <a id="destroy"></a>
 ## kvm.destroy


### PR DESCRIPTION
This PR also introduce some small minor new features and a behaviour change

## Behaviour change
- No port_open call is needed for the port forward to start accepting connections. 
- Port forwards (for both container, and VMs) can no handle more complex (source) port syntax. For example {2200: 22} means accept ALL connection from 2200 and redirect to 22 (on destination), we can now also do {ip:2200, 22}, {ip/mask:2200, 22}, or {devname:2200, 22} for example

## Minor features
To make it easy to configure start up service that requires different setting based on kernel params (booting modes) we added support for arguments conditions.

Plus the global service condition that control the entire service, each argument can now also prefixed with a condition string.