### PR TITLE
Set hostname during boot (using zerotier-id)

### DIFF
--- a/apps/core0/bootstrap/network/dhcp.go
+++ b/apps/core0/bootstrap/network/dhcp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/zero-os/0-core/base/pm"
 )
@@ -19,15 +20,6 @@ func init() {
 }
 
 type dhcpProtocol struct {
-}
-
-func (d *dhcpProtocol) getZerotierId() (string, error) {
-	bytes, err := ioutil.ReadFile("/tmp/zt/identity.public")
-	if err != nil {
-		return "", err
-	}
-
-	return string(bytes)[0:10], nil
 }
 
 func (d *dhcpProtocol) isPlugged(inf string) error {
@@ -48,12 +40,7 @@ func (d *dhcpProtocol) Configure(mgr NetworkManager, inf string) error {
 	// 	return err
 	// }
 
-	hostid := "hostname:zero-os"
-
-	ztid, err := d.getZerotierId()
-	if err == nil {
-		hostid = fmt.Sprintf("hostname:zero-os-%s", ztid)
-	}
+	hostid, _ := os.Hostname()
 
 	cmd := &pm.Command{
 		ID:      fmt.Sprintf("udhcpc/%s", inf),

--- a/apps/core0/conf/hostname.toml
+++ b/apps/core0/conf/hostname.toml
@@ -1,0 +1,10 @@
+# Set machine hostname, using zerotier id as variable
+
+[startup.hostname]
+name = "core.system"
+running_delay = -1
+after = ["zerotier-init"]
+
+[startup.hostname.args]
+name = "sh"
+args = ["-c", "hostname zero-os-$(cut -d: -f1 /tmp/zt/identity.public)"]


### PR DESCRIPTION
During boot, as soon as zerotier-id is generated, the hostname of the machine is set relative to it, following this: `zero-os-[zerotier-id]`

If the dhcp set hostname as option, this hostname is set and overwritten by the dhcp script later.

This closes #654 