### PR TITLE
Harden the parsing of btrfs filesystem show 

### DIFF
--- a/apps/core0/builtin/btrfs/btrfs.go
+++ b/apps/core0/builtin/btrfs/btrfs.go
@@ -193,7 +193,6 @@ func (m *btrfsManager) list(cmd *pm.Command, args []string) ([]btrfsFS, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	fss, err := m.parseList(result.Streams.Stdout())
 	if err != nil {
 		return nil, err
@@ -407,6 +406,10 @@ func (m *btrfsManager) parseList(output string) ([]btrfsFS, error) {
 
 	blocks := strings.Split(output, "\n\n")
 	for _, block := range blocks {
+		if strings.TrimSpace(block) == "" {
+			continue
+		}
+
 		warnings := ""
 		// Ensure that fsLines starts with Label (and collect all warnings into fs.Warnings)
 		labelIdx := strings.Index(block, "Label:")
@@ -447,7 +450,6 @@ func (m *btrfsManager) parseFS(lines []string) (btrfsFS, error) {
 	if _, err := fmt.Sscanf(strings.TrimSpace(lines[1]), "Total devices %d FS bytes used %d", &totDevice, &used); err != nil {
 		return btrfsFS{}, err
 	}
-
 	devs, err := m.parseDevices(lines[2:])
 	if err != nil {
 		return btrfsFS{}, err

--- a/apps/core0/builtin/btrfs/btrfs_test.go
+++ b/apps/core0/builtin/btrfs/btrfs_test.go
@@ -16,6 +16,16 @@ Label: 'single'  uuid: 74595911-0f79-4c2e-925f-105d1279fb48
 	Total devices 1 FS bytes used 196608
     devid    1 size 1048576000 used 138412032 path /dev/loop3
 `
+
+	fsStringWithWarnings = `warning, device 2 is missing
+Label: 'ROOT'  uuid: b8049c50-f0a4-4d6b-b6dc-6523ff577e26
+  Total devices 2 FS bytes used 42279981056
+  devid    1 size 42949672960 used 42949672960 path /dev/sda4
+
+  Label: 'single'  uuid: 74595911-0f79-4c2e-925f-105d1279fb48
+  Total devices 1 FS bytes used 196608
+  devid    1 size 1048576000 used 138412032 path /dev/loop3
+`
 )
 
 func TestParseFS(t *testing.T) {
@@ -37,6 +47,27 @@ func TestParseFS(t *testing.T) {
 	assert.Equal(t, int64(1048576000), dev.Size)
 	assert.Equal(t, int64(218103808), dev.Used)
 	assert.Equal(t, "/dev/loop1", dev.Path)
+}
+
+func TestParseFSWithWarnings(t *testing.T) {
+	var m btrfsManager
+	fss, err := m.parseList(fsStringWithWarnings)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(fss))
+
+	fs := fss[0]
+	assert.Nil(t, err)
+	assert.Equal(t, "ROOT", fs.Label)
+	assert.Equal(t, "b8049c50-f0a4-4d6b-b6dc-6523ff577e26", fs.UUID)
+	assert.Equal(t, 2, fs.TotalDevices)
+	assert.Equal(t, int64(42279981056), fs.Used)
+
+	assert.Equal(t, 1, len(fs.Devices))
+	dev := fs.Devices[0]
+	assert.Equal(t, 1, dev.DevID)
+	assert.Equal(t, int64(42949672960), dev.Size)
+	assert.Equal(t, int64(42949672960), dev.Used)
+	assert.Equal(t, "/dev/sda4", dev.Path)
 }
 
 var (

--- a/apps/core0/builtin/btrfs/btrfs_test.go
+++ b/apps/core0/builtin/btrfs/btrfs_test.go
@@ -1,6 +1,7 @@
 package btrfs
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,15 @@ var (
 Label: 'single'  uuid: 74595911-0f79-4c2e-925f-105d1279fb48
 	Total devices 1 FS bytes used 196608
     devid    1 size 1048576000 used 138412032 path /dev/loop3
+`
+	fsString2 = `Label: 'sp_zos-cache'  uuid: e8784776-6288-49e2-9cb0-29e50707bd73
+	Total devices 1 FS bytes used 544014336
+	devid    1 size 5366611968 used 5354029056 path /dev/vdc1
+
+Label: 'dmdm'  uuid: 7977d80d-f9c9-4343-82d3-018bc54698b1
+	Total devices 2 FS bytes used 114688
+	devid    1 size 5368709120 used 1619001344 path /dev/vdd
+	devid    2 size 5368709120 used 1619001344 path /dev/vde
 `
 
 	fsStringWithWarnings = `warning, device 2 is missing
@@ -47,6 +57,20 @@ func TestParseFS(t *testing.T) {
 	assert.Equal(t, int64(1048576000), dev.Size)
 	assert.Equal(t, int64(218103808), dev.Used)
 	assert.Equal(t, "/dev/loop1", dev.Path)
+}
+
+func TestParseFS2(t *testing.T) {
+	var m btrfsManager
+	fss, err := m.parseList(fsString2)
+	fmt.Printf("%v\n", fss)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(fss))
+
+	fs := fss[0]
+	assert.Equal(t, 1, fs.TotalDevices)
+
+	fs = fss[1]
+	assert.Equal(t, 2, fs.TotalDevices)
 }
 
 func TestParseFSWithWarnings(t *testing.T) {


### PR DESCRIPTION
- Fixes #692
Basically we delay the parsing of the output for each section until we coollection all the data before the `Label` itself.

- Added test case similar to the one in the issue.


## Normal filesystem
```
~ # btrfs filesystem show
Label: 'dmdm'  uuid: b0551d08-e24c-4f5a-ba46-bed524335b9a
  Total devices 2 FS bytes used 112.00KiB
  devid    1 size 1.00GiB used 622.38MiB path /dev/vdd
  devid    2 size 5.00GiB used 622.38MiB path /dev/vde

Label: 'dsds'  uuid: 433c2e39-1ce3-460a-a04f-96fd79aabf65
  Total devices 2 FS bytes used 112.00KiB
  devid    1 size 5.00GiB used 1.51GiB path /dev/vdf
  devid    2 size 5.00GiB used 1.51GiB path /dev/vdg
```

client results
```ipython
In [9]: cl.btrfs.list()
Out[9]: 
[{'label': 'dmdm',
  'uuid': 'b0551d08-e24c-4f5a-ba46-bed524335b9a',
  'total_devices': 2,
  'used': 114688,
  'devices': [{'dev_id': 1,
    'size': 1073741824,
    'used': 652607488,
    'path': '/dev/vdd'},
   {'dev_id': 2, 'size': 5368709120, 'used': 652607488, 'path': '/dev/vde'}],
  'warnings': ''},
 {'label': 'dsds',
  'uuid': '433c2e39-1ce3-460a-a04f-96fd79aabf65',
  'total_devices': 2,
  'used': 114688,
  'devices': [{'dev_id': 1,
    'size': 5368709120,
    'used': 1619001344,
    'path': '/dev/vdf'},
   {'dev_id': 2, 'size': 5368709120, 'used': 1619001344, 'path': '/dev/vdg'}],
  'warnings': ''}]
```

## ruined filesystem with warning
```
~ # dd if=/dev/zero of=/dev/vdf bs=1024 count=5000
5000+0 records in
5000+0 records out
5120000 bytes (4.9MB) copied, 0.110477 seconds, 44.2MB/s
~ # btrfs filesystem show
warning, device 1 is missing
Label: 'dmdm'  uuid: b0551d08-e24c-4f5a-ba46-bed524335b9a
  Total devices 2 FS bytes used 112.00KiB
  devid    1 size 1.00GiB used 622.38MiB path /dev/vdd
  devid    2 size 5.00GiB used 622.38MiB path /dev/vde

Label: 'dsds'  uuid: 433c2e39-1ce3-460a-a04f-96fd79aabf65
  Total devices 2 FS bytes used 112.00KiB
  devid    2 size 5.00GiB used 1.51GiB path /dev/vdg
  *** Some devices missing
```

response from the client
```ipython
In [10]: cl.btrfs.list()
Out[10]: 
[{'label': 'dmdm',
  'uuid': 'b0551d08-e24c-4f5a-ba46-bed524335b9a',
  'total_devices': 2,
  'used': 114688,
  'devices': [{'dev_id': 1,
    'size': 1073741824,
    'used': 652607488,
    'path': '/dev/vdd'},
   {'dev_id': 2, 'size': 5368709120, 'used': 652607488, 'path': '/dev/vde'}],
  'warnings': ''},
 {'label': 'dsds',
  'uuid': '433c2e39-1ce3-460a-a04f-96fd79aabf65',
  'total_devices': 2,
  'used': 114688,
  'devices': [{'dev_id': 2,
    'size': 5368709120,
    'used': 1619001344,
    'path': '/dev/vdg'}],
  'warnings': '*** Some devices missing'}]
```