### PR TITLE
Production build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 OUTPUT = bin
 VERSION = base/version.go
+TAGS =
+
+ifneq ($(ZOSBUILD), )
+	TAGS = -tags $(ZOSBUILD)
+endif
 
 branch = $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
 revision = $(shell git rev-parse HEAD)
@@ -11,10 +16,10 @@ ldflagsX = '-w -s -X $(base).Branch=$(branch) -X $(base).Revision=$(revision) -X
 all: core0 coreX corectl redis-proxy
 
 core0: $(OUTPUT)
-	cd apps/core0 && go build -ldflags $(ldflags0) -o ../../$(OUTPUT)/$@
+	cd apps/core0 && go build $(TAGS) -ldflags $(ldflags0) -o ../../$(OUTPUT)/$@
 
 coreX: $(OUTPUT)
-	cd apps/coreX && GOOS=linux go build -ldflags $(ldflagsX) -o ../../$(OUTPUT)/$@
+	cd apps/coreX && GOOS=linux go build $(TAGS) -ldflags $(ldflagsX) -o ../../$(OUTPUT)/$@
 
 corectl: $(OUTPUT)
 	cd apps/corectl && go build -ldflags $(ldflags0) -o ../../$(OUTPUT)/$@

--- a/apps/core0/transport/filter.go
+++ b/apps/core0/transport/filter.go
@@ -1,0 +1,9 @@
+// +build !production
+
+package transport
+
+import "github.com/zero-os/0-core/base/pm"
+
+func (sink *Sink) allowedCommnad(cmd *pm.Command) bool {
+	return true
+}

--- a/apps/core0/transport/filter_production.go
+++ b/apps/core0/transport/filter_production.go
@@ -1,0 +1,25 @@
+// +build production
+
+package transport
+
+import "github.com/zero-os/0-core/base/pm"
+
+/*
+Blocked commands that are not only accepted via the transport
+
+We can't disable those command internally because they are used intensevly
+by the core0 itself to run utilities and other processes. (also configuration files)
+*/
+var blockedCommands = []string{
+	"core.system", "bash",
+}
+
+func (sink *Sink) allowedCommnad(cmd *pm.Command) bool {
+	for _, blocked := range blockedCommands {
+		if cmd.Command == blocked {
+			return false
+		}
+	}
+
+	return true
+}

--- a/base/utils/cmdline.go
+++ b/base/utils/cmdline.go
@@ -55,6 +55,9 @@ func parseKerenlOptions(content string) KernelOptions {
 	for _, option := range cmdline {
 		kv := strings.SplitN(option, "=", 2)
 		key := kv[0]
+		if !isValidParam(key) {
+			continue
+		}
 		value := ""
 		if len(kv) == 2 {
 			value = kv[1]

--- a/base/utils/cmdline_valid.go
+++ b/base/utils/cmdline_valid.go
@@ -1,0 +1,7 @@
+// +build !production
+
+package utils
+
+func isValidParam(key string) bool {
+	return true
+}

--- a/base/utils/cmdline_valid_production.go
+++ b/base/utils/cmdline_valid_production.go
@@ -1,0 +1,17 @@
+// +build production
+
+package utils
+
+var invalidKeys = []string{
+	"development", "debug",
+}
+
+func isValidParam(key string) bool {
+	for _, invalid := range invalidKeys {
+		if key == invalid {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
setting the env var `ZOSBUILD=production` before calling `make` will build core0 in production mode, where the development flag is always ignored and the core.system and bash commands are treated as `unknown commands`